### PR TITLE
Add specificities for wholesale markets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,22 @@
-*.egg-info
-build/
+# Byte-compiled / optimized files
+*.py[cod]
+__pycache__
 
-# Pytest cache
+# Python distribution / packaging
+build
+dist
+sdist
+eggs
+.eggs
+*.egg-info
+*.egg
+develop-eggs
+
+# Testing and local development
+.idea
 .cache
+
+# Local temporary files
+.DS_Store
+.localized
+*~

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,11 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     packages=find_packages(exclude=['tests']),
     install_requires=[
+        'pytz',
         'django',
         'structlog',
     ],

--- a/tests/test_settlement_periods.py
+++ b/tests/test_settlement_periods.py
@@ -1,102 +1,182 @@
+import pytz
 import datetime
 
 import pytest
-import pytz
 
 from xocto import settlement_periods
-from xocto.settlement_periods import convert_sp_and_date_to_utc, convert_utc_to_sp_and_date
+
+
+UTC_TZ = pytz.utc
+GB_TZ = pytz.timezone('Europe/London')
 
 
 @pytest.mark.parametrize("sp,date,expected", [
     # British time is GMT
-    (1, datetime.date(2016, 1, 1), pytz.utc.localize(datetime.datetime(2016, 1, 1, hour=0))),
-    (4, datetime.date(2016, 1, 1), pytz.utc.localize(datetime.datetime(2016, 1, 1, hour=1,
-                                                                       minute=30))),
-    (20, datetime.date(2016, 1, 1), pytz.utc.localize(datetime.datetime(2016, 1, 1, hour=9,
-                                                                        minute=30))),
+    (1, datetime.date(2017, 1, 1),
+     datetime.datetime(2016, 12, 31, hour=23, tzinfo=UTC_TZ)),
+    (48, datetime.date(2017, 1, 1),
+     datetime.datetime(2017, 1, 1, hour=22, minute=30, tzinfo=UTC_TZ)),
 
-    # British time is BST
-    (1, datetime.date(2016, 7, 1), pytz.utc.localize(datetime.datetime(2016, 6, 30, hour=23))),
-    (4, datetime.date(2016, 7, 1), pytz.utc.localize(datetime.datetime(2016, 7, 1, hour=0,
-                                                                       minute=30))),
-    (20, datetime.date(2016, 7, 1), pytz.utc.localize(datetime.datetime(2016, 7, 1, hour=8,
-                                                                        minute=30))),
+    # British time is GMT
+    (1, datetime.date(2017, 7, 1),
+     datetime.datetime(2017, 6, 30, hour=22, tzinfo=UTC_TZ)),
+    (48, datetime.date(2017, 7, 1),
+     datetime.datetime(2017, 7, 1, hour=21, minute=30, tzinfo=UTC_TZ)),
 
-    # Change clock forward day,
-    # from GMT to BST
-    (1, datetime.date(2016, 3, 27), pytz.utc.localize(datetime.datetime(2016, 3, 27, hour=0))),
-    (4, datetime.date(2016, 3, 27), pytz.utc.localize(datetime.datetime(2016, 3, 27, hour=1,
-                                                                        minute=30))),
-    (20, datetime.date(2016, 3, 27), pytz.utc.localize(datetime.datetime(2016, 3, 27, hour=9,
-                                                                         minute=30))),
+    # Change clock forward day, from GMT to BST
+    (3, datetime.date(2017, 3, 26),
+     datetime.datetime(2017, 3, 26, hour=0, tzinfo=UTC_TZ)),
+    (5, datetime.date(2017, 3, 26),
+     datetime.datetime(2017, 3, 26, hour=1, tzinfo=UTC_TZ)),
+    (7, datetime.date(2017, 3, 26),
+     datetime.datetime(2017, 3, 26, hour=2, tzinfo=UTC_TZ)),
+    (45, datetime.date(2017, 3, 26),
+     datetime.datetime(2017, 3, 26, hour=21, tzinfo=UTC_TZ)),
 
-    # Change clock backward day,
-    # from BST to GMT
-    (1, datetime.date(2015, 10, 25), pytz.utc.localize(datetime.datetime(2015, 10, 24, hour=23))),
-    (4, datetime.date(2015, 10, 25), pytz.utc.localize(datetime.datetime(2015, 10, 25, hour=0,
-                                                                         minute=30))),
-    (20, datetime.date(2015, 10, 25), pytz.utc.localize(datetime.datetime(2015, 10, 25, hour=8,
-                                                                          minute=30))),
+    # Change clock backward day, from BST to GMT
+    (5, datetime.date(2017, 10, 29),
+     datetime.datetime(2017, 10, 29, hour=0, tzinfo=UTC_TZ)),
+    (7, datetime.date(2017, 10, 29),
+     datetime.datetime(2017, 10, 29, hour=1, tzinfo=UTC_TZ)),
+    (9, datetime.date(2017, 10, 29),
+     datetime.datetime(2017, 10, 29, hour=2, tzinfo=UTC_TZ)),
+    (49, datetime.date(2017, 10, 29),
+     datetime.datetime(2017, 10, 29, hour=22, tzinfo=UTC_TZ)),
 ])
-def test_convert_sp_and_date_to_utc(sp, date, expected):
+def test_convert_sp_and_date_to_utc_for_wholesale(sp, date, expected):
     """
-    Test the convert_sp_and_date_to_utc function
-    for days where british time is the same as GMT,
-    where british time is BST,
-    and change days
+    Test the convert_sp_and_date_to_utc function within a wholesale context
+    for days where british time is the same as GMT, where british time is BST, and change days
     """
-    assert convert_sp_and_date_to_utc(sp, date) == expected
+    assert settlement_periods.convert_sp_and_date_to_utc(
+        sp, date, is_wholesale=True) == expected
 
 
 @pytest.mark.parametrize("utc,sp,date", [
     # British time is GMT
-    (datetime.datetime(2016, 1, 1, hour=0, tzinfo=pytz.utc),
-     1, datetime.datetime(2016, 1, 1).date()),
-    (datetime.datetime(2016, 1, 1, hour=1, minute=30, tzinfo=pytz.utc),
-     4, datetime.datetime(2016, 1, 1).date()),
-    (datetime.datetime(2016, 1, 1, hour=9, minute=30, tzinfo=pytz.utc),
-     20, datetime.datetime(2016, 1, 1).date()),
+    (datetime.datetime(2016, 12, 31, hour=23, minute=30, tzinfo=UTC_TZ),
+     2, datetime.date(2017, 1, 1)),
+    (datetime.datetime(2017, 1, 1, hour=22, tzinfo=UTC_TZ),
+     47, datetime.date(2017, 1, 1)),
+
+    # British time is GMT
+    (datetime.datetime(2017, 6, 30, hour=22, minute=30, tzinfo=UTC_TZ),
+     2, datetime.date(2017, 7, 1)),
+    (datetime.datetime(2017, 7, 1, hour=21, tzinfo=UTC_TZ),
+     47, datetime.date(2017, 7, 1)),
+
+    # Change clock forward day, from GMT to BST
+    (datetime.datetime(2017, 3, 26, hour=0, minute=30, tzinfo=UTC_TZ),
+     4, datetime.date(2017, 3, 26)),
+    (datetime.datetime(2017, 3, 26, hour=1, minute=30, tzinfo=UTC_TZ),
+     6, datetime.date(2017, 3, 26)),
+    (datetime.datetime(2017, 3, 26, hour=2, minute=30, tzinfo=UTC_TZ),
+     8, datetime.date(2017, 3, 26)),
+    (datetime.datetime(2017, 3, 26, hour=21, minute=30, tzinfo=UTC_TZ),
+     46, datetime.date(2017, 3, 26)),
+
+    # Change clock backward day, from BST to GMT
+    (datetime.datetime(2017, 10, 29, hour=0, minute=30, tzinfo=UTC_TZ),
+     6, datetime.date(2017, 10, 29)),
+    (datetime.datetime(2017, 10, 29, hour=1, minute=30, tzinfo=UTC_TZ),
+     8, datetime.date(2017, 10, 29)),
+    (datetime.datetime(2017, 10, 29, hour=2, minute=30, tzinfo=UTC_TZ),
+     10, datetime.date(2017, 10, 29)),
+    (datetime.datetime(2017, 10, 29, hour=22, minute=30, tzinfo=UTC_TZ),
+     50, datetime.date(2017, 10, 29)),
+])
+def test_convert_utc_to_sp_and_date_for_wholesale(utc, sp, date):
+    """
+    Test the convert_utc_to_sp_and_date function within a wholesale context
+    for days where british time is the same as GMT, where british time is BST, and change days
+    """
+    assert settlement_periods.convert_utc_to_sp_and_date(
+        utc, is_wholesale=True) == (sp, date)
+
+
+@pytest.mark.parametrize("sp,date,expected", [
+    # British time is GMT
+    (1, datetime.date(2016, 1, 1),
+     datetime.datetime(2016, 1, 1, hour=0, tzinfo=UTC_TZ)),
+    (4, datetime.date(2016, 1, 1),
+     datetime.datetime(2016, 1, 1, hour=1, minute=30, tzinfo=UTC_TZ)),
+    (20, datetime.date(2016, 1, 1),
+     datetime.datetime(2016, 1, 1, hour=9, minute=30, tzinfo=UTC_TZ)),
 
     # British time is BST
-    (datetime.datetime(2016, 6, 30, hour=23, tzinfo=pytz.utc),
-     1, datetime.datetime(2016, 7, 1).date()),
-    (datetime.datetime(2016, 7, 1, hour=0, minute=30, tzinfo=pytz.utc),
-     4, datetime.datetime(2016, 7, 1).date()),
-    (datetime.datetime(2016, 7, 1, hour=8, minute=30, tzinfo=pytz.utc),
-     20, datetime.datetime(2016, 7, 1).date()),
+    (1, datetime.date(2016, 7, 1),
+     datetime.datetime(2016, 6, 30, hour=23, tzinfo=UTC_TZ)),
+    (4, datetime.date(2016, 7, 1),
+     datetime.datetime(2016, 7, 1, hour=0, minute=30, tzinfo=UTC_TZ)),
+    (20, datetime.date(2016, 7, 1),
+     datetime.datetime(2016, 7, 1, hour=8, minute=30, tzinfo=UTC_TZ)),
 
-    # Change clock forward day,
-    # From GMT to BST
-    (datetime.datetime(2016, 3, 27, hour=0, tzinfo=pytz.utc),
-     1, datetime.datetime(2016, 3, 27).date()),
-    (datetime.datetime(2016, 3, 27, hour=1, minute=30, tzinfo=pytz.utc),
-     4, datetime.datetime(2016, 3, 27).date()),
-    (datetime.datetime(2016, 3, 27, hour=9, minute=30, tzinfo=pytz.utc),
-     20, datetime.datetime(2016, 3, 27).date()),
+    # Change clock forward day, from GMT to BST
+    (1, datetime.date(2016, 3, 27),
+     datetime.datetime(2016, 3, 27, hour=0, tzinfo=UTC_TZ)),
+    (4, datetime.date(2016, 3, 27),
+     datetime.datetime(2016, 3, 27, hour=1, minute=30, tzinfo=UTC_TZ)),
+    (20, datetime.date(2016, 3, 27),
+     datetime.datetime(2016, 3, 27, hour=9, minute=30, tzinfo=UTC_TZ)),
 
-    # Change clock backward day,
-    # from BST to GMT
-    (datetime.datetime(2016, 10, 24, hour=23, tzinfo=pytz.utc),
-     1, datetime.datetime(2016, 10, 25).date()),
-    (datetime.datetime(2016, 10, 25, hour=0, minute=30, tzinfo=pytz.utc),
-     4, datetime.datetime(2016, 10, 25).date()),
-    (datetime.datetime(2016, 10, 25, hour=8, minute=30, tzinfo=pytz.utc),
-     20, datetime.datetime(2016, 10, 25).date()),
+    # Change clock backward day, from BST to GMT
+    (1, datetime.date(2015, 10, 25),
+     datetime.datetime(2015, 10, 24, hour=23, tzinfo=UTC_TZ)),
+    (4, datetime.date(2015, 10, 25),
+     datetime.datetime(2015, 10, 25, hour=0, minute=30, tzinfo=UTC_TZ)),
+    (20, datetime.date(2015, 10, 25),
+     datetime.datetime(2015, 10, 25, hour=8, minute=30, tzinfo=UTC_TZ)),
 ])
-def test_convert_utc_to_sp_and_date(utc, sp, date):
+def test_convert_sp_and_date_to_utc_for_retail(sp, date, expected):
     """
-    Test the convert_utc_to_sp_and_date function
-    for days where british time is the same as GMT,
-    where british time is BST,
-    and change days
+    Test the convert_sp_and_date_to_utc function within a retail context
+    for days where british time is the same as GMT, where british time is BST, and change days
     """
+    assert settlement_periods.convert_sp_and_date_to_utc(sp, date) == expected
 
-    assert convert_utc_to_sp_and_date(utc) == (sp, date)
+
+@pytest.mark.parametrize("utc,sp,date", [
+    # British time is GMT
+    (datetime.datetime(2016, 1, 1, hour=0, tzinfo=UTC_TZ),
+     1, datetime.date(2016, 1, 1)),
+    (datetime.datetime(2016, 1, 1, hour=1, minute=30, tzinfo=UTC_TZ),
+     4, datetime.date(2016, 1, 1)),
+    (datetime.datetime(2016, 1, 1, hour=9, minute=30, tzinfo=UTC_TZ),
+     20, datetime.date(2016, 1, 1)),
+
+    # British time is BST
+    (datetime.datetime(2016, 6, 30, hour=23, tzinfo=UTC_TZ),
+     1, datetime.date(2016, 7, 1)),
+    (datetime.datetime(2016, 7, 1, hour=0, minute=30, tzinfo=UTC_TZ),
+     4, datetime.date(2016, 7, 1)),
+    (datetime.datetime(2016, 7, 1, hour=8, minute=30, tzinfo=UTC_TZ),
+     20, datetime.date(2016, 7, 1)),
+
+    # Change clock forward day, From GMT to BST
+    (datetime.datetime(2016, 3, 27, hour=0, tzinfo=UTC_TZ),
+     1, datetime.date(2016, 3, 27)),
+    (datetime.datetime(2016, 3, 27, hour=1, minute=30, tzinfo=UTC_TZ),
+     4, datetime.date(2016, 3, 27)),
+    (datetime.datetime(2016, 3, 27, hour=9, minute=30, tzinfo=UTC_TZ),
+     20, datetime.date(2016, 3, 27)),
+
+    # Change clock backward day, from BST to GMT
+    (datetime.datetime(2016, 10, 24, hour=23, tzinfo=UTC_TZ),
+     1, datetime.date(2016, 10, 25)),
+    (datetime.datetime(2016, 10, 25, hour=0, minute=30, tzinfo=UTC_TZ),
+     4, datetime.date(2016, 10, 25)),
+    (datetime.datetime(2016, 10, 25, hour=8, minute=30, tzinfo=UTC_TZ),
+     20, datetime.date(2016, 10, 25)),
+])
+def test_convert_utc_to_sp_and_date_for_retail(utc, sp, date):
+    """
+    Test the convert_utc_to_sp_and_date function within a retail context
+    for days where british time is the same as GMT, where british time is BST, and change days
+    """
+    assert settlement_periods.convert_utc_to_sp_and_date(utc) == (sp, date)
 
 
-@pytest.mark.parametrize(
-    "start,end,periods",
-    [
+@pytest.mark.parametrize("start,end,periods", [
         (datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 1, 1, 0, 30), 1),
         (datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 1, 1, 4, 0), 8),
         (datetime.datetime(2016, 1, 1, 0, 0), datetime.datetime(2016, 1, 2, 0, 30), 49),
@@ -104,11 +184,10 @@ def test_convert_utc_to_sp_and_date(utc, sp, date):
         (datetime.datetime(2018, 3, 25, 0, 0), datetime.datetime(2018, 3, 26, 0, 0), 46),
         # Clocks go backwards here: 25 hours in the day
         (datetime.datetime(2018, 10, 28, 0, 0), datetime.datetime(2018, 10, 29, 0, 0), 50),
-    ]
-)
+])
 def test_number_of_settlement_periods_in_timedelta(start, end, periods):
-    tz = pytz.timezone('Europe/London')
-    start = tz.normalize(tz.localize(start))
-    end = tz.normalize(tz.localize(end))
+    start = GB_TZ.normalize(GB_TZ.localize(start))
+    end = GB_TZ.normalize(GB_TZ.localize(end))
     delta = end - start
+
     assert settlement_periods.number_of_periods_in_timedelta(delta) == periods

--- a/xocto/exceptions.py
+++ b/xocto/exceptions.py
@@ -1,0 +1,4 @@
+class SettlementPeriodError(Exception):
+    """
+    Basic exception raised while converting tz-aware datetime
+    """

--- a/xocto/settlement_periods.py
+++ b/xocto/settlement_periods.py
@@ -1,61 +1,134 @@
+import pytz
+import typing
 import datetime
 
-import pytz
+from . import exceptions
 
 
-def _to_timezone(value, timezone):
+__all__ = [
+    'convert_sp_and_date_to_utc',
+    'convert_utc_to_sp_and_date',
+    'number_of_periods_in_timedelta'
+]
+
+
+# Time zones implemented
+UTC_TZ = "UTC"
+GB_TZ = "Europe/London"
+
+
+def _to_timezone(local_time: datetime.datetime, timezone_str: str) -> datetime.datetime:
     """
-    Converts an aware datetime.datetime to the given time.
+    Converts an aware datetime to another time zone.
     """
-    value = value.astimezone(timezone)
-    if hasattr(timezone, 'normalize'):
-        # This method is available for pytz time zones.
-        value = timezone.normalize(value)
-    return value
+    timezone = pytz.timezone(timezone_str)
+    # Rebasing to local time zone
+    rebased_local_time = local_time.astimezone(timezone)
+    # Normalizing for daylight saving rules
+    return timezone.normalize(rebased_local_time)
 
 
-def convert_sp_and_date_to_utc(sp, date, timezone="Europe/London"):
+def _get_first_delivery_time(date: datetime.date, timezone_str: str,
+                             is_wholesale: bool) -> datetime.datetime:
     """
-    Return the datetime for the start of a given settlement period.
-
-    We assume the time of the first SP period of the day is 00:00 local time.
-
-    :param sp: Integer representing the settlement period (between 1 and 48)
-    :param date: date object
-    :param string: The local timezone of the date
-    :return: UTC representation of the given SP and Date
+    Return an aware datetime for the start of the first settlement period on a given date.
     """
-    local_midnight = pytz.timezone(timezone).localize(
-        datetime.datetime(date.year, date.month, date.day, hour=0, minute=0, second=0))
-    return _to_timezone(local_midnight, pytz.UTC) + datetime.timedelta(minutes=(sp - 1) * 30)
+    midnight = datetime.datetime(date.year, date.month, date.day)
+    offset_midnight = midnight - datetime.timedelta(hours=1)
+    # First settlement period
+    cases = {
+        # UTC: first delivery starts at 00:00:00 UTC on the day
+        UTC_TZ: midnight,
+        # GB retail: first delivery starts at 00:00:00 Europe/London on the day
+        # GB wholesale: first delivery starts at 23:00:00 Europe/London on the previous day
+        GB_TZ: offset_midnight if is_wholesale else midnight,
+    }
+    # Time zone aware
+    try:
+        return pytz.timezone(timezone_str).localize(cases[timezone_str])
+    except AttributeError:
+        raise exceptions.SettlementPeriodError("Time zone not implemented")
 
 
-def convert_utc_to_sp_and_date(utc_datetime, timezone="Europe/London"):
+def _get_delivery_date(local_time: datetime.datetime, timezone_str: str,
+                       is_wholesale: bool) -> datetime.date:
     """
-    Convert a timezone-naive datetime object, in UTC, to a SP (Settlement Period) and Date
-    combination.
-
-    :param utc_datetime: datetime timezone-aware object in UTC
+    Return the date of the settlement period relative to a tz-aware datetime.
     """
-    # Flatten the minutes to the nearest half hour
-    if utc_datetime.minute < 30:
-        minutes = 0
+    period_date = local_time.date()
+    offset_period_date = period_date
+    if local_time.hour >= 23:
+        offset_period_date += datetime.timedelta(days=1)
+    # Date of the first settlement period
+    cases = {
+        # UTC: first delivery starts at 00:00:00 UTC on the day
+        UTC_TZ: period_date,
+        # GB retail: first delivery starts at 00:00:00 Europe/London on the day
+        # GB wholesale: first delivery starts at 23:00:00 Europe/London on the previous day
+        GB_TZ: offset_period_date if is_wholesale else period_date,
+    }
+    # Time zone aware
+    try:
+        return cases[timezone_str]
+    except AttributeError:
+        raise exceptions.SettlementPeriodError("Time zone not implemented")
+
+
+def convert_sp_and_date_to_local(sp: int, date: datetime.date, timezone_str: str,
+                                 is_wholesale: bool) -> datetime.datetime:
+    """
+    Return an aware datetime for the start of a given settlement period.
+    """
+    if sp not in range(1, 51):
+        raise exceptions.SettlementPeriodError("Settlement period not valid")
+    # First settlement period in the time zone
+    first_period_start = _get_first_delivery_time(date, timezone_str, is_wholesale)
+    # Start of the settlement period in local time
+    local_time = first_period_start + datetime.timedelta(minutes=30 * (sp - 1))
+    # Normalizing for daylight saving rules
+    return pytz.timezone(timezone_str).normalize(local_time)
+
+
+def convert_sp_and_date_to_utc(sp: int, date: datetime.date, timezone_str: str=GB_TZ,
+                               is_wholesale: bool = False) -> datetime.datetime:
+    """
+    Return an UTC-aware datetime for the start of a given settlement period.
+    """
+    local_time = convert_sp_and_date_to_local(sp, date, timezone_str, is_wholesale)
+    return _to_timezone(local_time, UTC_TZ)
+
+
+def convert_local_to_sp_and_date(local_time: datetime.datetime,
+                                 is_wholesale: bool=False) -> typing.Tuple[int, datetime.date]:
+    """
+    Return the date and settlement period from a given tz-aware datetime.
+    """
+    try:
+        timezone_str = str(local_time.tzinfo)
+    except AttributeError:
+        raise exceptions.SettlementPeriodError("Not a tz-aware datetime")
+    # Round to the nearest half hour
+    if local_time.minute < 30:
+        half_hourly_time = local_time.replace(minute=0)
     else:
-        minutes = 30
-    utc_datetime = utc_datetime.replace(minute=minutes)
+        half_hourly_time = local_time.replace(minute=30)
+    # Date of the settlement period in the time zone
+    delivery_date = _get_delivery_date(half_hourly_time, timezone_str, is_wholesale)
+    # First settlement period in the time zone
+    first_delivery_time = _get_first_delivery_time(delivery_date, timezone_str, is_wholesale)
+    # Fetch settlement period
+    delta = half_hourly_time - first_delivery_time
+    settlement_period = ((int(delta.total_seconds()) // 60) + 30) // 30
+    return settlement_period, delivery_date
 
-    # Convert dt to localtime
-    local_timezone = pytz.timezone(timezone)
-    local_dt = _to_timezone(utc_datetime, local_timezone)
 
-    # We re-create the midnight object so the DST settings are correct
-    d = datetime.datetime(local_dt.year, local_dt.month, local_dt.day)
-    local_midnight = local_timezone.localize(d, local_timezone)
-
-    delta = local_dt - local_midnight
-    minutes_delta = (delta.seconds // 60) + 30
-    sp = minutes_delta // 30
-    return sp, local_dt.date()
+def convert_utc_to_sp_and_date(utc_time: datetime.datetime, timezone_str: str=GB_TZ,
+                               is_wholesale: bool=False) -> typing.Tuple[int, datetime.date]:
+    """
+    Return the local date and settlement period from a given UTC-aware datetime.
+    """
+    local_time = _to_timezone(utc_time, timezone_str)
+    return convert_local_to_sp_and_date(local_time, is_wholesale)
 
 
 def number_of_periods_in_timedelta(delta: datetime.timedelta):


### PR DESCRIPTION
Extend the xocto.settlement_periods module to convert datetime into date and settlement periods as well as vice versa. Considered cases are:

- Data storage: first settlement period starts at 00:00:00 UTC on the day

- UK retail: first settlement period starts at 00:00:00 Europe/London on the day

- UK wholesale: first settlement period starts at 23:00:00 Europe/London on the previous day
(https://www.apxgroup.com/trading-clearing/uk-half-hour-day-ahead-1530-auction/)