### PR TITLE
Make local to sp pandas compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
             'flake8==3.0.4',
             'pytest==3.0.2',
             'pytest-django==3.0.0',
+            'pandas==0.23',
         ],
     },
 )

--- a/xocto/settlement_periods.py
+++ b/xocto/settlement_periods.py
@@ -76,9 +76,9 @@ def _get_delivery_date(local_time: datetime.datetime, timezone_str: str,
 
 def _round_local_down_to_hh(local_time):
     if local_time.minute < 30:
-        return local_time.replace(minute=0)
+        return local_time - datetime.timedelta(minutes=local_time.minute)
     else:
-        return local_time.replace(minute=30)
+        return local_time - datetime.timedelta(minutes=local_time.minute - 30)
 
 
 def convert_sp_and_date_to_local(sp: int, date: datetime.date, timezone_str: str,

--- a/xocto/settlement_periods.py
+++ b/xocto/settlement_periods.py
@@ -74,6 +74,13 @@ def _get_delivery_date(local_time: datetime.datetime, timezone_str: str,
         raise exceptions.SettlementPeriodError("Time zone not implemented")
 
 
+def _round_local_down_to_hh(local_time):
+    if local_time.minute < 30:
+        return local_time.replace(minute=0)
+    else:
+        return local_time.replace(minute=30)
+
+
 def convert_sp_and_date_to_local(sp: int, date: datetime.date, timezone_str: str,
                                  is_wholesale: bool) -> datetime.datetime:
     """
@@ -108,10 +115,7 @@ def convert_local_to_sp_and_date(local_time: datetime.datetime,
     except AttributeError:
         raise exceptions.SettlementPeriodError("Not a tz-aware datetime")
     # Round to the nearest half hour
-    if local_time.minute < 30:
-        half_hourly_time = local_time.replace(minute=0)
-    else:
-        half_hourly_time = local_time.replace(minute=30)
+    half_hourly_time = _round_local_down_to_hh(local_time)
     # Date of the settlement period in the time zone
     delivery_date = _get_delivery_date(half_hourly_time, timezone_str, is_wholesale)
     # First settlement period in the time zone


### PR DESCRIPTION
At the moment, `convert_local_to_sp_and_date` fails on clock-change-back days when using `pd.Timestamp` instead of `datetime.datetime`, due to a slight difference in how `.replace` works between the two ([see this issue](https://github.com/pandas-dev/pandas/issues/25017)).

Admittedly the typing on the function specifies `datetime.datetime`, but since pandas forces you to use `pd.Timestamp` in series index,  (and the two are supposed to be _basically_ the same) I think its worth having a solution that works for both. Also `.replace` is a little more tricky to reason what should happen with regards to timezones, rather than just adding / subtracting minutes.

Also this adds pandas to the test requirements in order to get at the Timestamps, which might not be desirable.