### PR TITLE
Add py.typed file to xocto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.6",
     ],
-    packages=find_packages(exclude=["tests"]),
+    packages=["xocto", "xocto.events"],
+    package_data={"xocto": ["py.typed"]},
+    zip_safe=False,
     install_requires=[
         "pytz==2022.1",
         "django==3.2.13",


### PR DESCRIPTION
This allows mypy to use new types defined in xocto while type checking. For more information see: https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages