### PR TITLE
Fix is local time when using datetime timezone UTC

### DIFF
--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -363,6 +363,12 @@ class TestIsLocalime:
         local_dt = timezone.get_current_timezone().normalize(local_dt)
         assert localtime.is_local_time(local_dt)
 
+    def test_datetime_utc(self):
+        dt = datetime.datetime(2016, 8, 5, tzinfo=datetime.timezone.utc)
+        # Should not raise:
+        #     AttributeError: 'datetime.timezone' object has no attribute '_utcoffset'
+        assert not localtime.is_local_time(dt)
+
 
 # Alias to make the pytest parameters fit on one line
 ldt = localtime.datetime

--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -345,6 +345,8 @@ def is_local_time(dt):
     """
     Test whether a given (timezone-aware) datetime is in local time or not.
     """
+    if dt.tzinfo is datetime_.timezone.utc:
+        dt = dt.replace(tzinfo=pytz.utc)
     current_timezone = timezone.get_current_timezone()
     return current_timezone.normalize(dt).tzinfo == dt.tzinfo
 


### PR DESCRIPTION
Previously, the `is_local_time()` function would crash with the following error when passing a datetime object that uses the Python's datetime timezone UTC.

    AttributeError: 'datetime.timezone' object has no attribute '_utcoffset'

This change ensures we swap the Python's datetime timezone UTC for a pytz UTC before calling `normalize()`.