### PR TITLE
Use Python's datetime UTC instead of pytz

### DIFF
--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -854,6 +854,12 @@ class TestCombine:
                 datetime.datetime(2020, 1, 1, tzinfo=pytz.UTC),
             ),
             (
+                factories.date("1 Jan 2020"),
+                factories.time("00:00"),
+                "UTC",
+                datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
+            ),
+            (
                 factories.date("1 Jun 2020"),
                 factories.time("01:00"),
                 "Europe/London",

--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -24,7 +24,7 @@ far_future = timezone.make_aware(datetime_.datetime.max - datetime_.timedelta(da
 # Timezone aware datetime in the far past.
 far_past = timezone.make_aware(datetime_.datetime.min + datetime_.timedelta(days=2))
 
-UTC = pytz.UTC
+UTC = datetime_.timezone.utc
 LONDON = pytz.timezone("Europe/London")
 
 ONE_DAY = datetime_.timedelta(days=1)
@@ -46,7 +46,7 @@ def as_utc(dt):
     """
     Wrapper for normalizing a datetime aware object into UTC.
     """
-    return as_localtime(dt, pytz.utc)
+    return as_localtime(dt, datetime_.timezone.utc)
 
 
 def now() -> datetime_.datetime:
@@ -278,6 +278,8 @@ def latest(_date=None, tz=None):
 
 def combine(_date: datetime_.date, _time: datetime_.time, tz) -> datetime_.datetime:
     combined_dt = datetime_.datetime.combine(_date, _time)
+    if tz is datetime_.timezone.utc:
+        return combined_dt.replace(tzinfo=tz)
     return tz.localize(combined_dt)
 
 
@@ -329,7 +331,7 @@ def make_aware_assuming_utc(dt):
     """
     Return a timezone-aware datetime (in UTC) given a naive datetime.
     """
-    return pytz.utc.localize(dt)
+    return timezone.make_aware(dt, timezone=UTC)
 
 
 def is_utc(dt: datetime_.datetime) -> bool:


### PR DESCRIPTION
This change swaps uses of pytz UTC to instead use Python's datetime UTC as part of an effort to remove the legacy pytz library altogether.

Merging this PR will incur a major version bump of the xocto package.