### PR TITLE
Remove the `assert_never` helper

### DIFF
--- a/xocto/types.py
+++ b/xocto/types.py
@@ -2,7 +2,7 @@
 Utility types to save having to redefine the same things over and over.
 """
 
-from typing import Generic, NoReturn, Protocol, Tuple, TypeVar, Union
+from typing import Generic, Protocol, Tuple, TypeVar, Union
 
 from django.contrib.auth import models as auth_models
 from django.db import models
@@ -60,12 +60,3 @@ class AuthenticatedRequest(HttpRequest, Generic[User]):
     """
 
     user: User
-
-
-def assert_never(value: NoReturn) -> NoReturn:
-    """
-    Helper to ensure checks are exhaustive.
-
-    For more information see https://hakibenita.com/python-mypy-exhaustive-checking.
-    """
-    raise TypeError(f"Unhandled value: {value} ({type(value).__name__})")


### PR DESCRIPTION
This function is now part of the stdlib `typing` module from Python 3.11
and has been backported in `typing_extensions`. A custom implementation
is no longer necessary now there is a standard implementation.

---

This is technically a breaking change. Would it be better to continue to export this function but just proxy the one from `typing`/`typing-extensions`?