### PR TITLE
Expose storage module

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,31 @@ from xocto import localtime
 
 See [xocto.localtime](xocto/localtime.py) for more details, including examples and in depth technical details.
 
+### Storage
+
+This module is used to communicate with AWS S3. It also includes a helper for file-like objects.
+
+It's been over the years internally in Kraken Technologies, and is heavily used internally.
+
+Here's and example of how to use the main functionalities, such as upload and download a file:
+
+```python
+from xocto.storage import storage
+
+def upoad_file():
+    file_name = "file_name"
+    contents = "contents"  # Contents can be AnyStr or ReadableBinaryFile
+    storage_provider = storage.from_uri("s3-destination-uri")
+    storage_provider.store_file(
+        namespace="namespace", filename=file_name, contents=contents
+    )
+
+def download_file():
+   storage_provider = storage.S3FileStore("bucket-name")
+   storage_provider.download_file("a/b/c.pdf")
+```
+
+
 ## Development
 
 ### Installation

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.8",
     ],
-    packages=["xocto", "xocto.events"],
+    packages=["xocto", "xocto.events", "xocto.storage"],
     package_data={"xocto": ["py.typed"]},
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
This PR defines `xocto.storage` as a package in setup.py, so storage module is usable when importing `xocto` library. Also, README is updated including storage module brief explanation.