### PR TITLE
Setup autodoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,15 +10,16 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
 
+import django
 
-# TODO: Use with autodoc
-# from django.conf import settings
+sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("."))
 
-# settings.configure()
+os.environ["DJANGO_SETTINGS_MODULE"] = "doc_settings"
+django.setup()
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ import sys
 
 import django
 
-sys.path.insert(0, os.path.abspath(".")) # for discovery of doc_settings.py
+sys.path.insert(0, os.path.abspath("."))  # for discovery of doc_settings.py
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "doc_settings"
 django.setup()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,7 @@ import sys
 
 import django
 
-sys.path.insert(0, os.path.abspath(".."))
-sys.path.insert(0, os.path.abspath("."))
+sys.path.insert(0, os.path.abspath(".")) # for discovery of doc_settings.py
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "doc_settings"
 django.setup()

--- a/docs/doc_settings.py
+++ b/docs/doc_settings.py
@@ -1,0 +1,9 @@
+"""
+Placeholder file so Sphinx can import the project for autodocumenting.
+"""
+
+# INSTALLED_APPS with these apps is necessary for Sphinx to build without warnings & errors
+INSTALLED_APPS = [
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+]

--- a/docs/xocto/events.md
+++ b/docs/xocto/events.md
@@ -46,3 +46,11 @@ events.publish(
     account=account
 )
 ```
+
+## API Reference
+
+```{eval-rst}
+.. autofunction:: xocto.events.publish
+
+.. autofunction:: xocto.events.Timer
+```

--- a/docs/xocto/localtime.md
+++ b/docs/xocto/localtime.md
@@ -18,3 +18,12 @@ from xocto import localtime
 ```
 
 See [xocto.localtime](https://github.com/octoenergy/xocto/blob/master/xocto/localtime.py) for more details, including examples and in depth technical details.
+
+## API Reference
+
+```{eval-rst}
+.. automodule:: xocto.localtime
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/xocto/numbers.md
+++ b/docs/xocto/numbers.md
@@ -14,3 +14,12 @@ from xocto.numbers import quantise
 ```
 
 See [xocto.numbers](https://github.com/octoenergy/xocto/blob/master/xocto/numbers.py) for more details, including examples and in depth technical details.
+
+## API Reference
+
+```{eval-rst}
+.. automodule:: xocto.numbers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/xocto/ranges.md
+++ b/docs/xocto/ranges.md
@@ -8,9 +8,8 @@ The basic building block of the module is the `Range` class.
 
 A few examples:
 
-from xocto.ranges import Range, RangeBoundaries
-
 ```python
+from xocto.ranges import Range, RangeBoundaries
 > > > Range(0, 2, boundaries=RangeBoundaries.EXCLUSIVE_INCLUSIVE)
 > > > <Range: (0,2]>
 > > > 0 in Range(0, 2)
@@ -24,3 +23,12 @@ from xocto.ranges import Range, RangeBoundaries
 ```
 
 See [xocto.ranges](https://github.com/octoenergy/xocto/blob/master/xocto/ranges.py) for more details, including examples and in depth technical details.
+
+## API Reference
+
+```{eval-rst}
+.. automodule:: xocto.ranges
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/xocto/storage.md
+++ b/docs/xocto/storage.md
@@ -4,7 +4,7 @@
 
 Storage is an AWS S3 communication utility. It also includes a helper for file-like objects. It's been used for years at Kraken Tech, comes with extensive tests, and a growing set of documentation.
 
-## Usage
+## Basic Usage
 
 ```python
 import typing
@@ -34,4 +34,13 @@ def download_file(
     return file_store.fetch_file_contents(
         key_path=f"{namespace}/{filename}"
     )
+```
+
+## API Reference
+
+```{eval-rst}
+.. automodule:: xocto.storage.storage
+   :members:
+   :undoc-members:
+   :show-inheritance:
 ```


### PR DESCRIPTION
- Loaded Django into Sphinx so autodoc would work
- Added more directory levels to the path so autodoc can discover Python modules
- Added autodoc for all modules

Note: The Sphinx theme we're using isn't the best for autodoc, we'll move to a new theme in a separate PR.