### PR TITLE
Change theme to RTD standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ develop-eggs
 
 # Sphinx docs
 docs/_build
+docs/_static

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/xocto/ranges.md
+++ b/docs/xocto/ranges.md
@@ -10,15 +10,17 @@ A few examples:
 
 from xocto.ranges import Range, RangeBoundaries
 
->>> Range(0, 2, boundaries=RangeBoundaries.EXCLUSIVE_INCLUSIVE)
-<Range: (0,2]>
->>> 0 in Range(0, 2)
-True
->>> 2 in Range(0, 2)
-False
->>> date(2020, 1, 1) in Range(date(2020, 1, 2), date(2020, 1, 5))
-False
->>> sorted([Range(1, 4), Range(0, 5)])
-[<Range: [0,5)>, <Range: [1,4)>]
+```python
+> > > Range(0, 2, boundaries=RangeBoundaries.EXCLUSIVE_INCLUSIVE)
+> > > <Range: (0,2]>
+> > > 0 in Range(0, 2)
+> > > True
+> > > 2 in Range(0, 2)
+> > > False
+> > > date(2020, 1, 1) in Range(date(2020, 1, 2), date(2020, 1, 5))
+> > > False
+> > > sorted([Range(1, 4), Range(0, 5)])
+> > > [<Range: [0,5)>, <Range: [1,4)>]
+```
 
 See [xocto.ranges](https://github.com/octoenergy/xocto/blob/master/xocto/ranges.py) for more details, including examples and in depth technical details.


### PR DESCRIPTION
While Alabaster is lovely, the styling of autodoc isn't as legible as the RTD theme. Also fixed the ranges page while I was at it.