### PR TITLE
Update type annotation in get_finite_datetime_ranges_from_timestamps

### DIFF
--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -794,7 +794,7 @@ class FiniteDateRange(FiniteRange[datetime.date]):
 
 
 def get_finite_datetime_ranges_from_timestamps(
-    finite_datetime_range: FiniteDatetimeRange,
+    finite_datetime_range: FiniteRange[datetime.datetime],
     timestamps: list[datetime.datetime],
 ) -> Sequence[FiniteDatetimeRange]:
     """


### PR DESCRIPTION
Before this change, the `finite_datetime_range` argument to this function had the type `FiniteDatetimeRange`.

The function doesn't use any of the methods from that class and works when called on objects of its parent type
`FiniteRange[datetime.datetime]`, so this change updates the type annotation to reflect that.

This caused an issue for me when iterating through a FiniteRangeSet and calling this function - the following works, but mypy currently doesn't allow it:
```python
range_set = FiniteRangeSet(
    [FiniteDatetimeRange(datetime.datetime(2023, 1, 1), datetime.datetime(2023, 1, 31))]
)
for datetime_range in range_set:
    get_finite_datetime_ranges_from_timestamps(datetime_range, [])
```
Gives this error:
```
error: Argument 1 to "get_finite_datetime_ranges_from_timestamps" has incompatible type "FiniteRange[datetime]"; expected "FiniteDatetimeRange"  [arg-type]
```