### PR TITLE
Bump version to v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v2.4.0 - 2023-02-28
+
+Includes:
+
+- Many type annotations added ([#33](https://github.com/octoenergy/xocto/pull/33)).
+- Type annotation for `get_finite_datetime_ranges_from_timestamps` updated ([#37](https://github.com/octoenergy/xocto/pull/37)).
+- Added the `localtime` function `period_exceeds_one_year` for determining whether a datetime period 
+  exceeds one year ([#41](https://github.com/octoenergy/xocto/pull/41)).
+
 ## v2.3.0 - 2023-01-20
 
 Includes:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 REPO_ROOT = path.abspath(path.dirname(__file__))
 
-VERSION = "2.3.0"
+VERSION = "2.4.0"
 
 with open(path.join(REPO_ROOT, "README.md"), encoding="utf-8") as f:
     long_description = f.read()


### PR DESCRIPTION
I followed https://xocto.readthedocs.io/en/latest/xocto/development.html#publishing

`make publish` failed at the `git push` part since `main` is a protected branch...

It was already published to pypi (sorry), since that part came first and did not fail.