### PR TITLE
Add missing pyarrow dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "structlog>=20.2.0",
         "python-dateutil>=2.8.2",
         "pact-python>=1.6.0",
+        "pyarrow>=11.0.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Used by the `convert_csv_to_parquet` function as the Pandas conversion engine as shown here: https://github.com/octoenergy/xocto/blob/4c8119511fc62dfd98456131d1bd39a0a57edb5e/xocto/storage/files.py#L202