### PR TITLE
Bump version to v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.1.0 - 2023-03-07
+
+Includes:
+
+- Addition of get_git_branch_name function for PACT testing ([#40](https://github.com/octoenergy/xocto/pull/40))
+
 ## v3.0.0 - 2023-02-28
 
 Includes:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 REPO_ROOT = path.abspath(path.dirname(__file__))
 
-VERSION = "3.0.0"
+VERSION = "3.1.0"
 
 with open(path.join(REPO_ROOT, "README.md"), encoding="utf-8") as f:
     long_description = f.read()


### PR DESCRIPTION
Addition of get_git_branch_name function for PACT testing

Many apologies, it looks like this has already been released on PyPi after following the instructions [here](https://xocto.readthedocs.io/en/latest/xocto/development.html#publishing) but committing the bump failed as main is protected.