### PR TITLE
Accept iterable instead of list

### DIFF
--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -795,7 +795,7 @@ class FiniteDateRange(FiniteRange[datetime.date]):
 
 def get_finite_datetime_ranges_from_timestamps(
     finite_datetime_range: FiniteRange[datetime.datetime],
-    timestamps: list[datetime.datetime],
+    timestamps: Iterable[datetime.datetime],
 ) -> Sequence[FiniteDatetimeRange]:
     """
     Given a datetime range and some timestamps, cut that period into


### PR DESCRIPTION
There's no reason this needs to be a `list` in particular.

When [upgrading Kraken's xocto version](https://github.com/octoenergy/kraken-core/pull/79737), this is causing a lot of noise as we need to unnecessarily convert a lot of `set[datetime.datetime]` into `list[datetime.datetime`.