### PR TITLE
Defer openpyxl import

### DIFF
--- a/xocto/storage/files.py
+++ b/xocto/storage/files.py
@@ -11,7 +11,6 @@ import os
 import tempfile
 from typing import IO, Any, AnyStr, Callable
 
-import openpyxl
 import pandas as pd
 import xlrd
 
@@ -69,6 +68,8 @@ def convert_xlsx_to_csv(
 
     """
     # data_only to extract values from formulae and not formulas themselves
+    import openpyxl
+
     workbook = openpyxl.load_workbook(xlsx_filepath, data_only=True, read_only=True)
     sheet = workbook.active
 


### PR DESCRIPTION
Easy win stolen wholesale from this Wednesday's django london talk

See https://adamj.eu/tech/2023/03/02/django-profile-and-improve-import-time/#defer-imports

openpyxl takes ~0.2 seconds to import. This is included in every pytest run whether convert_xlsx_to_csv is used or not.


~This also fixes the main branch which is broken since the release of django 4.2 by silencing the pytz usage issues. Maybe another spaday task!~