### PR TITLE
Update makefile and docs with the new publish method in CONTRIBUTORS

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-install: 
+install:
 	pip install -e .[dev,test]
 
 clean:
@@ -6,21 +6,12 @@ clean:
 	-rm -rf dist/ *.egg-info/ build/
 	-find . -type d -name __pycache__ -delete
 
-build_package:
-	@echo Building package
-	python setup.py bdist_wheel
-
-upload_package:
-	@echo Uploading package to PyPI
-	twine upload dist/*
-
 VERSION=$(shell python setup.py --version)
 
 tag:
 	@echo Tagging as $(VERSION)
-	git tag $(VERSION)
-	git push
-	git push --tags
+	git tag -a $(VERSION) -m "xoct $(VERSION)"
+	git push origin $(VERSION)
 
 publish: clean build_package upload_package tag
 
@@ -43,4 +34,3 @@ docker_images:
 	docker build -t xocto/pytest --target=pytest .
 	docker build -t xocto/isort --target=isort .
 	docker build -t xocto/black --target=black .
-


### PR DESCRIPTION
Prior to this change, makefile wasn't using the new GH workflow for publishing package to PyPI

This change updates the makefile to follow the new workflow.