### PR TITLE
Fix main branch for django 4.2 release/Ignore some deprecated in django 5 warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,10 @@ filterwarnings =
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3:DeprecationWarning:(graphene|singledispatch)
     # https://github.com/ktosiek/pytest-freezegun/issues/35
     ignore:distutils Version classes are deprecated:DeprecationWarning:pytest_freezegun
+    # These deprecation warnings were added in django 4.2 to warn of removal in django 5
+    ignore:The USE_DEPRECATED_PYTZ setting:django.utils.deprecation.RemovedInDjango50Warning
+    ignore:The django.utils.timezone.utc alias is deprecated:django.utils.deprecation.RemovedInDjango50Warning
+    ignore:The is_dst argument to make_aware:django.utils.deprecation.RemovedInDjango50Warning
 
 DJANGO_SETTINGS_MODULE=tests.settings
 


### PR DESCRIPTION
Since the release of django 4.2, the main branch is now failing. This will require removing pytz in favour of zoneinfo. This pr silences those warnings for now instead of fixing all pytz usages. This is in lieu of actually doing the pytz -> zoneinfo changes which is happening in https://github.com/octoenergy/xocto/pull/61