### PR TITLE
Add localtime function to translate months to German

### DIFF
--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -694,6 +694,25 @@ def translate_english_month_to_spanish(month: int) -> str:
     return month_name_lookup[month_name]
 
 
+def translate_english_month_to_german(month: int) -> str:
+    english_month_name = calendar.month_name[month]
+    month_name_lookup = {
+        "January": "Januar",
+        "February": "Februar",
+        "March": "März",
+        "April": "April",
+        "May": "Mai",
+        "June": "Juni",
+        "July": "Juli",
+        "August": "August",
+        "September": "September",
+        "October": "Oktober",
+        "November": "November",
+        "December": "Dezember",
+    }
+    return month_name_lookup[english_month_name]
+
+
 def period_exceeds_one_year(start_at: DateTime, end_at: DateTime) -> bool:
     """
     Returns true if the passed period exceeds one year.


### PR DESCRIPTION
~Copy-pasted from~Inspired by the very similar function `translate_english_month_to_spanish`, this commit adds a small helper to the localtime module that takes in a month as `int` and returns the German month name as `str`.
