### PR TITLE
Ranges: add utils to check period covering

### DIFF
--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -561,3 +561,40 @@ class TestBreakPeriodsOnTimestamp:
             ranges.FiniteDatetimeRange(splits[1], splits[0]),
             ranges.FiniteDatetimeRange(splits[0], period.end),
         ]
+
+
+class TestAnyOverlapping:
+    @pytest.mark.parametrize(
+        "ranges_",
+        [
+            [
+                ranges.Range(0, 2),
+                ranges.Range(1, 3),
+            ],
+            [
+                ranges.Range(0, 2, boundaries=ranges.RangeBoundaries.INCLUSIVE_INCLUSIVE),
+                ranges.Range(2, 4),
+            ],
+        ],
+    )
+    def test_returns_true_if_and_ranges_overlap(self, ranges_):
+        assert ranges.any_overlapping(ranges_)
+
+    @pytest.mark.parametrize(
+        "ranges_",
+        [
+            [
+                ranges.Range(0, 2),
+                ranges.Range(2, 4),
+            ],
+            [
+                ranges.Range(0, 2),
+                ranges.Range(2, 4, boundaries=ranges.RangeBoundaries.EXCLUSIVE_INCLUSIVE),
+            ],
+        ],
+    )
+    def test_returns_false_if_no_ranges_overlap(self, ranges_):
+        assert not ranges.any_overlapping(ranges_)
+
+    def test_returns_false_for_empty_set_of_ranges(self):
+        assert not ranges.any_overlapping([])

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -832,3 +832,15 @@ def get_finite_datetime_ranges_from_timestamps(
         # or end of the period.
         if start != end
     ]
+
+
+def any_overlapping(ranges: Sequence[Range[T]]) -> bool:
+    """Return true if any of the passed Ranges are overlapping."""
+    if not ranges:
+        return False
+    range_set = RangeSet[T]([ranges[0]])
+    for range in ranges[1:]:
+        if range_set.intersection(range):
+            return True
+        range_set.add(range)
+    return False


### PR DESCRIPTION
Adding ~two~ one utility functions to the ranges module here.

* ~`period_is_fully_covered` checks whether the passed period is fully covered by the passed ranges.~ Already exists in `RangeSet.contains_range`.
* `any_overlapping` checks whether any of the passed ranges overlap.   