### PR TITLE
Adds support for test coverage reports

### DIFF
--- a/makefile
+++ b/makefile
@@ -30,6 +30,9 @@ lint:
 test:
 	py.test
 
+coverage:
+	py.test --cov=xocto
+
 black:
 	black -v --check .
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
             "flake8==6.0.0",
             "hypothesis==6.62.1",
             "moto[s3,sqs]==4.1",
+            "pytest-cov>=4.0.0"
             "pytest-django==4.5.2",
             "pytest-mock==3.10.0",
             "pytest==7.2.1",


### PR DESCRIPTION
Adds make command to generate a test coverage report.  Example below.

```shell
> pytest --cov=xocto

Name                          Stmts   Miss  Cover
-------------------------------------------------
xocto/__init__.py                 1      0   100%
xocto/events/__init__.py          2      0   100%
xocto/events/core.py             37     18    51%
xocto/events/utils.py            10      0   100%
xocto/exceptions.py               1      0   100%
xocto/health.py                  15      5    67%
xocto/localtime.py              236     37    84%
xocto/numbers.py                 39      6    85%
xocto/pact_testing.py            36     36     0%
xocto/ranges.py                 299     47    84%
xocto/settlement_periods.py      58      7    88%
xocto/storage/__init__.py         0      0   100%
xocto/storage/files.py           75     17    77%
xocto/storage/s3_select.py       59      3    95%
xocto/storage/storage.py        704    219    69%
xocto/tracing.py                 16     16     0%
xocto/types.py                   24      5    79%
-------------------------------------------------
TOTAL                          1612    416    74%
```

Adds `makefile` command `coverage`

`make coverage` 