### PR TITLE
Update error message for ranges with unbounded end

### DIFF
--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -174,7 +174,7 @@ class Range(Generic[T]):
                 raise ValueError("Range with unbounded start must be left-exclusive")
         elif self.end is None:
             if self._is_right_inclusive:
-                raise ValueError("Ranges with unbounded ends must be right-inclusive")
+                raise ValueError("Range with unbounded end must be right-exclusive")
         else:
             check_op = {
                 RangeBoundaries.EXCLUSIVE_EXCLUSIVE: operator.lt,


### PR DESCRIPTION
Quick update to accurately indicate the required inclusivity when initiating a `Range` with unbounded end. 
Replaced the previous error message for better clarity and adherence to the desired behaviour.