### PR TITLE
Revert "SPA Day: Check type for variable in list of classes"

### DIFF
--- a/xocto/storage/s3_select.py
+++ b/xocto/storage/s3_select.py
@@ -58,9 +58,12 @@ class BaseSerializer:
         temp_dict = {k: v for k, v in dataclasses.asdict(self).items() if v}
 
         for k, v in temp_dict.items():
-            if type(v) in [FileHeaderInfo, QuoteFields, CompressionType]:
+            if (
+                isinstance(v, FileHeaderInfo)
+                or isinstance(v, QuoteFields)
+                or isinstance(v, CompressionType)
+            ):
                 temp_dict[k] = v.value
-
         return temp_dict
 
 


### PR DESCRIPTION
Reverts octoenergy/xocto#76 
Changing back to original code. Reasoning: although we aren't using inheritance at the moment, we might in the future. using `type(v)` doesn't check for inheritance whereas `isinstance(v, Class)` does. 