### PR TITLE
Add v prefix to tags to trigger GH actions

### DIFF
--- a/makefile
+++ b/makefile
@@ -31,10 +31,9 @@ docker_images:
 
 # Releases
 
-VERSION=$(shell python setup.py --version)
+VERSION=v$(shell python setup.py --version)
 
 tag:
 	@echo Tagging as $(VERSION)
 	git tag -a $(VERSION) -m "Creating version $(VERSION)"
 	git push origin $(VERSION)
-


### PR DESCRIPTION
The PyPI GH action looks for tags prefixed with `v`:

```yaml
on:
  push:
    tags:
      - v*
```

This one letter PR simply adds the necessary `v` to the version of the tag.