### PR TITLE
Check end=None for EXCLUSIVE_INCLUSIVE

### DIFF
--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -56,8 +56,10 @@ def test_creation():
         (0, 0, ranges.RangeBoundaries.EXCLUSIVE_EXCLUSIVE),
         (None, 0, ranges.RangeBoundaries.INCLUSIVE_INCLUSIVE),
         (None, 0, ranges.RangeBoundaries.INCLUSIVE_EXCLUSIVE),
+        (None, None, ranges.RangeBoundaries.INCLUSIVE_EXCLUSIVE),
         (0, None, ranges.RangeBoundaries.INCLUSIVE_INCLUSIVE),
         (0, None, ranges.RangeBoundaries.EXCLUSIVE_INCLUSIVE),
+        (None, None, ranges.RangeBoundaries.EXCLUSIVE_INCLUSIVE),
     ],
 )
 def test_validation(start, end, boundaries):

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -172,10 +172,10 @@ class Range(Generic[T]):
         if self.start is None:
             if self._is_left_inclusive:
                 raise ValueError("Range with unbounded start must be left-exclusive")
-        elif self.end is None:
+        if self.end is None:
             if self._is_right_inclusive:
                 raise ValueError("Range with unbounded end must be right-exclusive")
-        else:
+        elif self.start is not None:
             check_op = {
                 RangeBoundaries.EXCLUSIVE_EXCLUSIVE: operator.lt,
                 RangeBoundaries.EXCLUSIVE_INCLUSIVE: operator.lt,


### PR DESCRIPTION
Till now the `self.end is None and self._is_right_inclusive` check isn’t happening when `self.start is None`.