### PR TITLE
Add project URLs to improve PyPI visuals

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,4 +72,9 @@ setup(
             "time-machine==2.9.0",
         ],
     },
+    project_urls={
+        "Documentation": "https://xocto.readthedocs.io",
+        "Changelog": "https://github.com/octoenergy/xocto/blob/main/CHANGELOG.md",
+        "Issues": "https://github.com/octoenergy/xocto/issues",
+    },
 )


### PR DESCRIPTION
Increases PyPI side links from this very limited list to:

<img width="295" alt="Screenshot 2023-08-01 at 3 25 51 PM" src="https://github.com/octoenergy/xocto/assets/62857/97e6d8f0-bca4-4345-a9aa-d87733718e6f">

To this more useful list:

<img width="319" alt="Screenshot 2023-08-01 at 3 27 28 PM" src="https://github.com/octoenergy/xocto/assets/62857/68a0e9d4-a9b4-42c6-a7e7-f55210f1bf34">
