### PR TITLE
Widen type for ranges.any_overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.1.1 - 2023-09-06
+
+- Allow any iterable type in `ranges.any_overlapping` [#90](https://github.com/octoenergy/xocto/pull/90)
+
 ## v4.1.0 - 2023-09-01
 
 - Add URL utils [#87](https://github.com/octoenergy/xocto/pull/87)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 REPO_ROOT = path.abspath(path.dirname(__file__))
 
-VERSION = "4.1.0"
+VERSION = "4.1.1"
 
 with open(path.join(REPO_ROOT, "README.md"), encoding="utf-8") as f:
     long_description = f.read()

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -834,8 +834,9 @@ def get_finite_datetime_ranges_from_timestamps(
     ]
 
 
-def any_overlapping(ranges: Sequence[Range[T]]) -> bool:
+def any_overlapping(ranges: Iterable[Range[T]]) -> bool:
     """Return true if any of the passed Ranges are overlapping."""
+    ranges = list(ranges)
     if not ranges:
         return False
     range_set = RangeSet[T]([ranges[0]])


### PR DESCRIPTION
In response to [^1]. Allowing any iterable is more convenient for
the caller of this function.

[^1]: https://github.com/octoenergy/kraken-core/pull/100203#discussion_r1312518191