### PR TITLE
Add `RangeSet.is_(left|right)_finite` methods

### DIFF
--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -622,8 +622,14 @@ class RangeSet(Generic[T]):
         """
         return self.union(other)
 
+    def is_left_finite(self) -> bool:
+        return all(r.is_left_finite() for r in self._ranges)
+
+    def is_right_finite(self) -> bool:
+        return all(r.is_right_finite() for r in self._ranges)
+
     def is_finite(self) -> bool:
-        return all([r.is_finite() for r in self._ranges])
+        return all(r.is_finite() for r in self._ranges)
 
     def complement(self) -> RangeSet[T]:
         """


### PR DESCRIPTION
`is_finite`, `is_left_finite` and `is_right_finite` are all available on the underlying `Range` class, but only `is_finite` is currently available on `RangeSet`. This change adds the other two methods to `RangeSet`.