### PR TITLE
Fix bug in FiniteDateRange.days property

### DIFF
--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -600,3 +600,20 @@ class TestAnyOverlapping:
 
     def test_returns_false_for_empty_set_of_ranges(self):
         assert not ranges.any_overlapping([])
+
+
+class TestFiniteDateRange:
+    """
+    Test class for methods specific to the the FiniteDateRange subclass.
+    """
+
+    def test_days_property_has_correct_value(self):
+        """
+        As FiniteDateRange boundaries are double inclusive, the days
+        property should include the start and end dates in the count.
+        """
+        range = ranges.FiniteDateRange(
+            start=datetime.date(2000, 1, 1),
+            end=datetime.date(2000, 1, 2),
+        )
+        assert range.days == 2

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -798,7 +798,7 @@ class FiniteDateRange(FiniteRange[datetime.date]):
         """
         Return the number of days between the start and end of the range.
         """
-        return (self.end - self.start).days
+        return (self.end - self.start).days + 1
 
 
 def get_finite_datetime_ranges_from_timestamps(


### PR DESCRIPTION
Previously this property would return a value exclusive of the end
date. However the FiniteDateRange defines it's boundaries as double
inclusive, therefore this value was off by one.

This change includes the range end date in the count of days.
