### PR TITLE
Add localtime strftime

### DIFF
--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -1090,3 +1090,16 @@ class TestParseDatetime:
             localtime.parse_date("abcd")
 
         assert "Invalid isoformat string" in str(exc_info.value)
+
+
+class TestStrftime:
+    @override_settings(TIME_ZONE="Europe/Berlin")
+    def test_formats_datetime_in_local_timezone(self):
+        dt = datetime.datetime(2023, 10, 1, 22, 30, 0, tzinfo=timezone.utc)
+        fmt = "%Y-%m-%d %H:%M:%S %z"
+
+        assert localtime.strftime(dt, fmt) == "2023-10-02 00:30:00 +0200"
+        assert (
+            localtime.strftime(dt, fmt, tz=zoneinfo.ZoneInfo("Europe/London"))
+            == "2023-10-01 23:30:00 +0100"
+        )

--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -749,3 +749,16 @@ def parse_dt(value: str, tz: zoneinfo.ZoneInfo | None = None) -> datetime_.datet
     """
     _datetime = datetime_.datetime.fromisoformat(value)
     return timezone.make_aware(_datetime, timezone=tz)
+
+
+def strftime(
+    dt: datetime_.datetime,
+    fmt: str,
+    tz: zoneinfo.ZoneInfo | None = None,
+) -> str:
+    """
+    Format a tz aware datetime in localtime.
+
+    Wrapper for `datetime.strftime`.
+    """
+    return as_localtime(dt, tz=tz).strftime(fmt)


### PR DESCRIPTION
Add a `localtime.strftime` as a convenience for formatting a datetime in the local timezone in a single step (rather than having to call `as_localtime` and then `strftime`).