### PR TITLE
Replace flake8 and isort with ruff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,3 @@ jobs:
           command: |
             . ~/venv/bin/activate
             make black
-      - run:
-          name: iSort
-          command: |
-            . ~/venv/bin/activate
-            make isort

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,4 +31,4 @@ jobs:
           name: Black
           command: |
             . ~/venv/bin/activate
-            make black
+            make black_check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.3.0 - 2023-10-12
+
+- Replaced flake8 and isort with ruff [#101](https://github.com/octoenergy/xocto/pull/101)
+- Updated types in localtime.py [#101](https://github.com/octoenergy/xocto/pull/101)
+
 ## v4.3.0 - 2023-09-27
 
 - Enable querying parquet files using `S3FileStore.fetch_object_contents_with_s3_select` and `LocalFileStore.fetch_object_contents_with_s3_select` [#95](https://github.com/octoenergy/xocto/pull/95/)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ import sys
 
 import django
 
+
 sys.path.insert(0, os.path.abspath(".."))  # for discovery of project modules
 sys.path.insert(0, os.path.abspath("."))  # for discovery of doc_settings.py
 

--- a/makefile
+++ b/makefile
@@ -10,23 +10,27 @@ clean:
 # Static analysis
 
 lint:
-	flake8
+	make black_check ruff mypy
 
-test:
-	py.test
+black_check:
+	black --check --diff .
 
-black:
-	black -v --check .
-
-isort:
-	isort --check-only .
+ruff:
+	ruff check .
 
 mypy:
 	mypy
 
+test:
+	py.test
+
+format:
+	ruff check --fix .
+	black .
+
 docker_images:
 	docker build -t xocto/pytest --target=pytest .
-	docker build -t xocto/isort --target=isort .
+	docker build -t xocto/ruff --target=ruff .
 	docker build -t xocto/black --target=black .
 
 # Releases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,6 @@ section-order = [
 
 [tool.ruff.isort.sections]
 "project" = [
-    "{{ cookiecutter.python_package_name }}",
+    "xocto",
     "tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,6 @@
 [tool.black]
 line-length = 99
 
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = "True"
-force_grid_wrap = 0
-use_parentheses = "True"
-line_length = 99
-skip_glob = "venv/*"
-
 [tool.mypy]
 # Specify which files to check.
 files = [
@@ -74,3 +66,38 @@ module = [
   "zoneinfo.*",
 ]
 ignore_missing_imports = true
+
+
+# Ruff
+# ----
+
+[tool.ruff]
+select = [
+    "E",  # pycodestyle
+    "F",  # pyflakes
+    "I",  # isort
+]
+ignore = [
+    "E501",  # line too long - black takes care of this for us
+]
+
+[tool.ruff.per-file-ignores]
+# Allow unused imports in __init__ files as these are convenience imports
+"**/__init__.py" = [ "F401" ]
+
+[tool.ruff.isort]
+lines-after-imports = 2
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "project",
+    "local-folder",
+]
+
+[tool.ruff.isort.sections]
+"project" = [
+    "{{ cookiecutter.python_package_name }}",
+    "tests",
+]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from os import path
 
 from setuptools import setup
 
+
 REPO_ROOT = path.abspath(path.dirname(__file__))
 
 VERSION = "4.3.0"
@@ -51,12 +52,12 @@ setup(
             "black==22.12.0",
             "boto3==1.26.53",
             "botocore==1.29.53",
-            "isort==5.11.4",
             "mypy-boto3-s3==1.26.0.post1",
             "mypy==0.991",
             "numpy==1.22.2",
             "pre-commit>=3.2.0",
             "pyarrow-stubs==10.0.1.6",
+            "ruff==0.0.292",
             "twine==4.0.2",
             "types-openpyxl==3.0.4.5",
             "types-python-dateutil==2.8.19.6",
@@ -65,7 +66,7 @@ setup(
             "wheel==0.38.4",
         ],
         "test": [
-            "flake8==6.0.0",
+            "ruff==0.0.292",
             "hypothesis==6.62.1",
             "moto[s3,sqs]==4.1",
             "pytest-django==4.5.2",

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests.storage.helpers import fixtures as fixture_helpers
 
+
 # Fixture (as in files used in testing) loading
 
 

--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -1,16 +1,17 @@
 import datetime
 import decimal
-import zoneinfo
 
 import pytest
 import time_machine
+import zoneinfo
 from dateutil import relativedelta
 from django.conf import settings
 from django.test import override_settings
 from django.utils import timezone
 
-from tests import factories
 from xocto import localtime
+
+from tests import factories
 
 
 class TestNow:

--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -9,9 +9,8 @@ from django.conf import settings
 from django.test import override_settings
 from django.utils import timezone
 
-from xocto import localtime
-
 from tests import factories
+from xocto import localtime
 
 
 class TestNow:

--- a/tests/test_settlement_periods.py
+++ b/tests/test_settlement_periods.py
@@ -5,6 +5,7 @@ import pytz
 
 from xocto import settlement_periods
 
+
 UTC_TZ = datetime.timezone.utc
 GB_TZ = pytz.timezone("Europe/London")
 

--- a/xocto/events/core.py
+++ b/xocto/events/core.py
@@ -6,6 +6,7 @@ import structlog
 from django import http
 from django.conf import settings
 
+
 logger = structlog.get_logger("events")
 
 __all__ = ["publish"]

--- a/xocto/events/utils.py
+++ b/xocto/events/utils.py
@@ -1,6 +1,7 @@
 import time
 from typing import Any
 
+
 __all__ = ["Timer"]
 
 

--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -19,7 +19,7 @@ far_future = timezone.make_aware(datetime_.datetime.max - datetime_.timedelta(da
 # Timezone aware datetime in the far past.
 far_past = timezone.make_aware(datetime_.datetime.min + datetime_.timedelta(days=2))
 
-UTC = datetime_.timezone.utc
+UTC = zoneinfo.ZoneInfo("UTC")
 LONDON = zoneinfo.ZoneInfo("Europe/London")
 
 ONE_DAY = datetime_.timedelta(days=1)
@@ -29,7 +29,7 @@ MIDNIGHT_TIME = datetime_.time(0, 0)
 
 
 def as_localtime(
-    dt: datetime_.datetime, tz: timezone.zoneinfo.ZoneInfo | None = None
+    dt: datetime_.datetime, tz: zoneinfo.ZoneInfo | None = None
 ) -> datetime_.datetime:
     """
     Convert a tz aware datetime to localtime.
@@ -72,7 +72,7 @@ def datetime(
 # Returning dates
 
 
-def date(dt: datetime_.datetime, tz: timezone.zoneinfo.ZoneInfo | None = None) -> datetime_.date:
+def date(dt: datetime_.datetime, tz: zoneinfo.ZoneInfo | None = None) -> datetime_.date:
     """
     Return the date of the given datetime in the given timezone, defaulting to local time.
 
@@ -89,49 +89,49 @@ def date(dt: datetime_.datetime, tz: timezone.zoneinfo.ZoneInfo | None = None) -
     return as_localtime(dt, tz=tz).date()
 
 
-def today(tz: timezone.zoneinfo.ZoneInfo | None = None) -> datetime_.date:
+def today(tz: zoneinfo.ZoneInfo | None = None) -> datetime_.date:
     """
     Return the current date in the provided timezone (or the local timezone if none is supplied).
     """
     return date(timezone.now(), tz)
 
 
-def yesterday(tz: timezone.zoneinfo.ZoneInfo | None = None) -> datetime_.date:
+def yesterday(tz: zoneinfo.ZoneInfo | None = None) -> datetime_.date:
     """
     Return the previous date in the provided timezone (or the local timezone if none is supplied).
     """
     return days_in_the_past(1, tz)
 
 
-def tomorrow(tz: timezone.zoneinfo.ZoneInfo | None = None) -> datetime_.date:
+def tomorrow(tz: zoneinfo.ZoneInfo | None = None) -> datetime_.date:
     """
     Return the next date in the provided timezone (or the local timezone if none is supplied).
     """
     return days_in_the_future(1, tz)
 
 
-def days_in_the_past(n: int, tz: timezone.zoneinfo.ZoneInfo | None = None) -> datetime_.date:
+def days_in_the_past(n: int, tz: zoneinfo.ZoneInfo | None = None) -> datetime_.date:
     """
     Return n days before the current date (in the provided or local timezone).
     """
     return today(tz) - relativedelta(days=n)
 
 
-def days_in_the_future(n: int, tz: timezone.zoneinfo.ZoneInfo | None = None) -> datetime_.date:
+def days_in_the_future(n: int, tz: zoneinfo.ZoneInfo | None = None) -> datetime_.date:
     """
     Return n days after the current date (in the provided or local timezone).
     """
     return today(tz) + relativedelta(days=n)
 
 
-def months_in_the_past(n: int, tz: timezone.zoneinfo.ZoneInfo | None = None) -> datetime_.date:
+def months_in_the_past(n: int, tz: zoneinfo.ZoneInfo | None = None) -> datetime_.date:
     """
     Return n months before the current date (in the provided or local timezone).
     """
     return today(tz) - relativedelta(months=n)
 
 
-def months_in_the_future(n: int, tz: timezone.zoneinfo.ZoneInfo | None = None) -> datetime_.date:
+def months_in_the_future(n: int, tz: zoneinfo.ZoneInfo | None = None) -> datetime_.date:
     """
     Return n months after the current date (in the provided or local timezone).
     """
@@ -139,7 +139,7 @@ def months_in_the_future(n: int, tz: timezone.zoneinfo.ZoneInfo | None = None) -
 
 
 def date_of_day_before(
-    dt: datetime_.datetime, tz: timezone.zoneinfo.ZoneInfo | None = None
+    dt: datetime_.datetime, tz: zoneinfo.ZoneInfo | None = None
 ) -> datetime_.date:
     """
     Return the date of the day before the datetime passed in.
@@ -197,7 +197,7 @@ def seconds_in_the_past(n: int) -> datetime_.datetime:
 
 def midnight(
     date_or_datetime: Optional[Union[datetime_.date, datetime_.datetime]] = None,
-    tz: Optional[datetime_.tzinfo] = None,
+    tz: Optional[zoneinfo.ZoneInfo] = None,
 ) -> datetime_.datetime:
     """
     Return a TZ-aware datetime for midnight of the passed date.
@@ -225,7 +225,7 @@ def midnight(
 
 def next_midnight(
     date_or_datetime: Optional[Union[datetime_.date, datetime_.datetime]] = None,
-    tz: Optional[datetime_.tzinfo] = None,
+    tz: Optional[zoneinfo.ZoneInfo] = None,
 ) -> datetime_.datetime:
     """
     Return the datetime for midnight of the following day to the date passed in.
@@ -249,7 +249,7 @@ def next_midnight(
 
 
 def midday(
-    _date: datetime_.date | None = None, tz: timezone.zoneinfo.ZoneInfo | None = None
+    _date: datetime_.date | None = None, tz: zoneinfo.ZoneInfo | None = None
 ) -> datetime_.datetime:
     """
     Return a TZ-aware datetime for midday of the passed date.
@@ -264,7 +264,7 @@ def midday(
 
 
 def datetime_from_date(
-    _date: datetime_.date, hour: int, tz: timezone.zoneinfo.ZoneInfo | None = None
+    _date: datetime_.date, hour: int, tz: zoneinfo.ZoneInfo | None = None
 ) -> datetime_.datetime:
     """
     Return a TZ-aware datetime for the hour of the passed date.
@@ -274,7 +274,7 @@ def datetime_from_date(
 
 
 def datetime_from_epoch_timestamp(
-    timestamp: int | float, tz: timezone.zoneinfo.ZoneInfo | None = None
+    timestamp: int | float, tz: zoneinfo.ZoneInfo | None = None
 ) -> datetime_.datetime:
     """
     Return a TZ-aware datetime for the passed epoch timestamp.
@@ -285,7 +285,7 @@ def datetime_from_epoch_timestamp(
 
 
 def latest(
-    _date: datetime_.date | None = None, tz: timezone.zoneinfo.ZoneInfo | None = None
+    _date: datetime_.date | None = None, tz: zoneinfo.ZoneInfo | None = None
 ) -> datetime_.datetime:
     """
     Return a TZ-aware datetime for the latest representable datetime of the passed date.
@@ -298,7 +298,9 @@ def latest(
     return timezone.make_aware(naive_midnight, timezone=tz)
 
 
-def combine(_date: datetime_.date, _time: datetime_.time, tz: timezone.zone) -> datetime_.datetime:
+def combine(
+    _date: datetime_.date, _time: datetime_.time, tz: zoneinfo.ZoneInfo
+) -> datetime_.datetime:
     """
     Return a TZ-aware datetime obtained by combining the given date and time.
 
@@ -312,7 +314,7 @@ def combine(_date: datetime_.date, _time: datetime_.time, tz: timezone.zone) -> 
 
 
 def date_boundaries(
-    _date: Optional[datetime_.date], tz: Optional[datetime_.tzinfo] = None
+    _date: Optional[datetime_.date], tz: Optional[zoneinfo.ZoneInfo] = None
 ) -> Tuple[datetime_.datetime, datetime_.datetime]:
     """
     Return a 2-tuple with the start and ending dt for the given date in the local timezone.
@@ -340,7 +342,7 @@ def month_boundaries(month: int, year: int) -> Tuple[datetime_.datetime, datetim
 
 
 def as_range(
-    _date: Optional[datetime_.date], tz: Optional[datetime_.tzinfo] = None
+    _date: Optional[datetime_.date], tz: Optional[zoneinfo.ZoneInfo] = None
 ) -> Tuple[datetime_.datetime, datetime_.datetime]:
     """
     Return a 2-tuple of the min and max datetimes for the given date.
@@ -619,7 +621,7 @@ def is_dst(local_time: datetime_.datetime) -> bool:
     return bool(local_time.dst())
 
 
-def is_localtime_midnight(dt: datetime_.datetime, tz: Optional[datetime_.tzinfo] = None) -> bool:
+def is_localtime_midnight(dt: datetime_.datetime, tz: Optional[zoneinfo.ZoneInfo] = None) -> bool:
     """
     Return whether the supplied datetime is at midnight (in the site's local time zone).
 
@@ -630,7 +632,7 @@ def is_localtime_midnight(dt: datetime_.datetime, tz: Optional[datetime_.tzinfo]
 
 
 def is_aligned_to_midnight(
-    range: ranges.FiniteDatetimeRange, tz: timezone.zoneinfo.ZoneInfo | None = None
+    range: ranges.FiniteDatetimeRange, tz: zoneinfo.ZoneInfo | None = None
 ) -> bool:
     """
     Return whether this range is aligned to localtime midnight.
@@ -739,7 +741,7 @@ def parse_date(value: str) -> datetime_.date:
     return datetime_.date.fromisoformat(value)
 
 
-def parse_dt(value: str, tz: timezone.zoneinfo.ZoneInfo | None = None) -> datetime_.datetime:
+def parse_dt(value: str, tz: zoneinfo.ZoneInfo | None = None) -> datetime_.datetime:
     """
     Returns a datetime.datetime for a given ISO format date/time string.
 

--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 import calendar
 import datetime as datetime_
 import decimal
-import zoneinfo
 from typing import Generator, Optional, Sequence, Tuple, Union
 
+import zoneinfo
 from dateutil import tz
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 
 from . import numbers, ranges
+
 
 # Timezone aware datetime in the far future.
 far_future = timezone.make_aware(datetime_.datetime.max - datetime_.timedelta(days=2))

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -5,7 +5,18 @@ import enum
 import functools
 import itertools
 import operator
-from typing import Any, Generic, Iterable, Iterator, List, Optional, Sequence, TypeVar, Union, cast
+from typing import (
+    Any,
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from . import types
 

--- a/xocto/settlement_periods.py
+++ b/xocto/settlement_periods.py
@@ -5,6 +5,7 @@ import pytz
 
 from . import exceptions
 
+
 __all__ = [
     "convert_sp_and_date_to_utc",
     "convert_utc_to_sp_and_date",

--- a/xocto/storage/files.py
+++ b/xocto/storage/files.py
@@ -11,6 +11,7 @@ import os
 import tempfile
 from typing import IO, Any, AnyStr, Callable
 
+
 XLRD_FLOAT_TYPE = 2
 
 

--- a/xocto/storage/storage.py
+++ b/xocto/storage/storage.py
@@ -42,6 +42,7 @@ from xocto import events, localtime
 
 from . import files, s3_select
 
+
 if TYPE_CHECKING:
     from _typeshed import WriteableBuffer
     from mypy_boto3_s3 import service_resource

--- a/xocto/tracing.py
+++ b/xocto/tracing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ddtrace
 
+
 tracer = ddtrace.tracer
 wrap = tracer.wrap
 

--- a/xocto/types.py
+++ b/xocto/types.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models.expressions import Combinable
 from django.http import HttpRequest
 
+
 # A type variable which can be used in generic types, and represents a Django model of some
 # description
 Model = TypeVar("Model", bound=models.Model)


### PR DESCRIPTION
Bringing xocto into alignment with other Kraken projects.

This identified a typing issue in the `xocto/localtime.py` module, which is why that module has non-formatting changes.