### PR TITLE
Bugfix FiniteDateRange intersection

### DIFF
--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -618,6 +618,36 @@ class TestFiniteDateRange:
         )
         assert range.days == 2
 
+    class TestIntersection:
+        def test_overlapping_ranges_will_intersect(self):
+            ranges_ = [
+                ranges.FiniteDateRange(
+                    start=datetime.date(2000, 1, 1),
+                    end=datetime.date(2000, 1, 3),
+                ),
+                ranges.FiniteDateRange(
+                    start=datetime.date(2000, 1, 3),
+                    end=datetime.date(2000, 1, 5),
+                ),
+            ]
+            assert ranges_[0] & ranges_[1] == ranges.FiniteDateRange(
+                start=datetime.date(2000, 1, 3),
+                end=datetime.date(2000, 1, 3),
+            )
+
+        def test_adjacent_ranges_wont_intersect(self):
+            ranges_ = [
+                ranges.FiniteDateRange(
+                    start=datetime.date(2000, 1, 1),
+                    end=datetime.date(2000, 1, 2),
+                ),
+                ranges.FiniteDateRange(
+                    start=datetime.date(2000, 1, 3),
+                    end=datetime.date(2000, 1, 4),
+                ),
+            ]
+            assert ranges_[0] & ranges_[1] is None
+
     class TestIsDisjoint:
         @pytest.mark.parametrize(
             "other",

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -794,7 +794,11 @@ class FiniteDateRange(FiniteRange[datetime.date]):
         """
         Intersections with finite ranges will always be finite.
         """
-        base_intersection = super().intersection(other)
+        try:
+            base_intersection = super().intersection(other)
+        except ValueError:
+            # This occurs when calling intersection on an adjacent date range.
+            return None
         if base_intersection is None:
             return None
 


### PR DESCRIPTION
The recent change to allow adjacent FiniteDateRanges to union (by
changing the behaviour of is_disjoint) broke the behaviour of
intersection for adjacent ranges, causing attempts to intersect
adjacent ranges to raise ValueError instead of returning None.

This change makes intersect on adjacent FiniteDateRanges return
None again.
