### PR TITLE
Adding explicit type for Optional Foreign Key

### DIFF
--- a/xocto/types.py
+++ b/xocto/types.py
@@ -23,6 +23,7 @@ User = TypeVar("User", bound=auth_models.AbstractBaseUser)
 # These are one-item Unions so that mypy knows they are type aliases and not strings
 ForeignKey = Union["models.ForeignKey[Union[Model, Combinable], Model]"]
 OneToOneField = Union["models.OneToOneField[Union[Model, Combinable], Model]"]
+OptionalForeignKey = Union["models.ForeignKey[Union[Model, Combinable, None], Union[Model, None]]"]
 
 
 # A type variable to describe the Django model choices kwarg


### PR DESCRIPTION
In a new enough version of mypy providing an optional to the existing `ForeignKey` type results in an error as `MyModel | None` does not satisfy the `models.Model` that the `Model` TypeVar is bound to