### PR TITLE
Improve autodoc of callables and variables

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,12 @@ release = "2.3.0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["myst_parser", "sphinx.ext.autodoc", "sphinx.ext.autosummary"]
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/xocto/events.md
+++ b/docs/xocto/events.md
@@ -50,6 +50,8 @@ events.publish(
 ## API Reference
 
 ```{eval-rst}
+.. module:: xocto.types
+
 .. autofunction:: xocto.events.publish
 
 .. autofunction:: xocto.events.Timer

--- a/docs/xocto/localtime.md
+++ b/docs/xocto/localtime.md
@@ -19,9 +19,24 @@ from xocto import localtime
 
 See [xocto.localtime](https://github.com/octoenergy/xocto/blob/master/xocto/localtime.py) for more details, including examples and in depth technical details.
 
+## Variables
+
+```{eval-rst}
+.. autodata:: xocto.localtime.far_future
+.. autodata:: xocto.localtime.far_past
+.. autodata:: xocto.localtime.UTC
+.. autodata:: xocto.localtime.LONDON
+.. autodata:: xocto.localtime.ONE_DAY
+.. autodata:: xocto.localtime.ONE_HOUR
+.. autodata:: xocto.localtime.MIDNIGHT_TIME
+```
+
 ## API Reference
 
 ```{eval-rst}
+
+.. module:: xocto.types
+
 .. automodule:: xocto.localtime
    :members:
    :undoc-members:

--- a/docs/xocto/numbers.md
+++ b/docs/xocto/numbers.md
@@ -18,6 +18,8 @@ See [xocto.numbers](https://github.com/octoenergy/xocto/blob/master/xocto/number
 ## API Reference
 
 ```{eval-rst}
+.. module:: xocto.types
+
 .. automodule:: xocto.numbers
    :members:
    :undoc-members:

--- a/docs/xocto/pact_testing.md
+++ b/docs/xocto/pact_testing.md
@@ -7,6 +7,8 @@ For use with [pact-python](https://github.com/pact-foundation/pact-python)
 ## API Reference
 
 ```{eval-rst}
+.. module:: xocto.types
+
 .. automodule:: xocto.pact_testing
    :members:
    :undoc-members:

--- a/docs/xocto/ranges.md
+++ b/docs/xocto/ranges.md
@@ -27,6 +27,8 @@ See [xocto.ranges](https://github.com/octoenergy/xocto/blob/master/xocto/ranges.
 ## API Reference
 
 ```{eval-rst}
+.. module:: xocto.types
+
 .. automodule:: xocto.ranges
    :members:
    :undoc-members:

--- a/docs/xocto/storage.md
+++ b/docs/xocto/storage.md
@@ -39,6 +39,8 @@ def download_file(
 ## API Reference
 
 ```{eval-rst}
+.. module:: xocto.types
+
 .. automodule:: xocto.storage.storage
    :members:
    :undoc-members:

--- a/docs/xocto/types.md
+++ b/docs/xocto/types.md
@@ -4,11 +4,30 @@
 
 Types is a collection of utility types to help with type checking.
 
+Utility types to save having to redefine the same things over and over.
+
+## Types
+
+```{eval-rst}
+
+.. autodata:: xocto.types.Model
+.. autodata:: xocto.types.ForeignKey
+.. autodata:: xocto.types.OneToOneField
+.. autodata:: xocto.types.OptionalForeignKey
+.. autodata:: xocto.types.Choices
+.. autodata:: xocto.types.T
+```
+
 ## API Reference
 
 ```{eval-rst}
+
+.. module:: xocto.types
+
 .. automodule:: xocto.types
    :members:
    :undoc-members:
    :show-inheritance:
 ```
+
+


### PR DESCRIPTION
Currently our docs are useful, but lack visibility in some modules as to what components are provided by the code. This forces the reader to dive into source code. While code diving is a good thing, our docs should better describe what the module does. Types is the worst offender, but Localtime can also be improved.

Also, we can make code diving easier.

What this does:

- Links autodocumented callables with their source code
- Uses the autodata function to document variables in types and localtime