### PR TITLE
Provide OptionalOneToOneField

### DIFF
--- a/xocto/types.py
+++ b/xocto/types.py
@@ -22,9 +22,12 @@ User = TypeVar("User", bound=auth_models.AbstractBaseUser)
 # Helpers for declaring django relations on classes
 # These are one-item Unions so that mypy knows they are type aliases and not strings
 ForeignKey = Union["models.ForeignKey[Union[Model, Combinable], Model]"]
-OneToOneField = Union["models.OneToOneField[Union[Model, Combinable], Model]"]
 OptionalForeignKey = Union["models.ForeignKey[Union[Model, Combinable, None], Union[Model, None]]"]
 
+OneToOneField = Union["models.OneToOneField[Union[Model, Combinable], Model]"]
+OptionalOneToOneField = Union[
+    "models.OneToOneField[Union[Model, Combinable, None], Union[Model, None]]"
+]
 
 # A type variable to describe the Django model choices kwarg
 Choices = Tuple[Tuple[str, str], ...]


### PR DESCRIPTION
In a new enough mypy trying to do `OneToOneField[MyModel | None]` will complain because an optional model does not satisfy the bound condition of the TypeVar we are using here.

This is the OneToOneField equivalent of https://github.com/octoenergy/xocto/pull/108, which I was meant to add but forgot.