### PR TITLE
Fix docs by adding missing RTD theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.8.0 - 2023-11-01
 
+- Fix docs by adding missing rtd theme [#115](https://github.com/octoenergy/xocto/pull/113)
 - Adding explicit type for Optional OneToOneField [#113](https://github.com/octoenergy/xocto/pull/113)
 - Fix `OverflowError` when calling `is_disjoint` on a range containing `date.min` or `date.max` [#112](https://github.com/octoenergy/xocto/pull/112)
 - Improve autodoc of callables and variables [#111](https://github.com/octoenergy/xocto/pull/111)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ mypy-boto3-s3==1.26.0.post1
 openpyxl==3.0.10
 structlog==22.3
 pact-python>=1.6.0
+sphinx-rtd-theme==1.3.0


### PR DESCRIPTION
Docs builds have failed for some time now. This fixes them, which can be checked by visiting the docs which are now set to this branch: https://xocto.readthedocs.io/en/latest/xocto/types.html

Note 1: Once this is approved, switch xocto's config on RTD back to the main branch.

Note 2: Using `pyproject.toml` will simplify the requirements and setup scheme, making this kind of failure less frequent. As I have a lot of recent experience in converting projects over I may do that on Spa Day.