### PR TITLE
Enable more than two adjacent FiniteDateRanges to be unioned

### DIFF
--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -757,6 +757,56 @@ class TestFiniteDateRange:
                 end=datetime.date(2000, 1, 4),
             )
 
+        def test_handles_many_adjacent_ranges(self):
+            """
+            As FiniteDateRange boundaries are double inclusive, when two ranges
+            end/start on consecutive days they effectively cover a fully contiguous
+            period of time and should make a union.
+
+            This should apply with an arbitrary number of adjacent ranges.
+            """
+            r1 = ranges.FiniteDateRange(
+                start=datetime.date(2000, 1, 1),
+                end=datetime.date(2000, 1, 2),
+            )
+            r2 = ranges.FiniteDateRange(
+                start=datetime.date(2000, 1, 3),
+                end=datetime.date(2000, 1, 5),
+            )
+            r3 = ranges.FiniteDateRange(
+                start=datetime.date(2000, 1, 6),
+                end=datetime.date(2000, 1, 8),
+            )
+
+            union = r1 | r2 | r3
+            assert union == ranges.FiniteDateRange(
+                start=datetime.date(2000, 1, 1),
+                end=datetime.date(2000, 1, 8),
+            )
+
+        def test_range_set_over_many_adjacent_ranges(self):
+            """
+            Multiple unions should be approximately equivalent to a RangeSet
+            """
+            r1 = ranges.FiniteDateRange(
+                start=datetime.date(2000, 1, 1),
+                end=datetime.date(2000, 1, 2),
+            )
+            r2 = ranges.FiniteDateRange(
+                start=datetime.date(2000, 1, 3),
+                end=datetime.date(2000, 1, 5),
+            )
+            r3 = ranges.FiniteDateRange(
+                start=datetime.date(2000, 1, 6),
+                end=datetime.date(2000, 1, 8),
+            )
+
+            range_set = ranges.RangeSet([r1, r2, r3])
+            assert ranges.FiniteDateRange(
+                start=datetime.date(2000, 1, 1),
+                end=datetime.date(2000, 1, 8),
+            ) in range_set
+
         @pytest.mark.parametrize(
             "range, other",
             [

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -824,6 +824,21 @@ class FiniteDateRange(FiniteRange[datetime.date]):
         assert base_intersection.boundaries == RangeBoundaries.INCLUSIVE_INCLUSIVE
         return FiniteDateRange(base_intersection.start, base_intersection.end)
 
+    def union(self, other: Range[datetime.date]) -> Optional["FiniteDateRange"]:
+        """
+        Unions between two FiniteDateRanges should produce a FiniteDateRange.
+        """
+        try:
+            base_union = super().union(other)
+        except ValueError:
+            return None
+
+        if base_union is None:
+            return None
+
+        assert base_union.boundaries == RangeBoundaries.INCLUSIVE_INCLUSIVE
+        return FiniteDateRange(base_union.start, base_union.end)
+
     def is_disjoint(self, other: Range[datetime.date]) -> bool:
         # Adjacent dates should not be considered disjoint, we extend the other
         # range to allow them to be considered adjacent.


### PR DESCRIPTION
Prior to this change, FiniteDateRange was able to correctly union with an adjacent FiniteDateRange, however, the union produced was of the base range type and was then unable to union with a successive adjacent range.

This change ensures that unioning two FiniteDateRanges produces a FiniteDateRange so that it can be unioned with a successive adjacent ranges.

Fixes https://github.com/octoenergy/xocto/issues/122