### PR TITLE
Bump version to v4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.9.0 - 2023-11-17
+
+- Modernize setup to use pyproject.toml [#116](https://github.com/octoenergy/xocto/pull/116)
+- Populate `xocto.__version__` from package metadata
+- Enables `FiniteDateRange` to be unioned with more than two ranges [#123](https://github.com/octoenergy/xocto/pull/123)
+
 ## v4.8.0 - 2023-11-02
 
 - Fix docs by adding missing rtd theme [#115](https://github.com/octoenergy/xocto/pull/113)

--- a/docs/xocto/development.md
+++ b/docs/xocto/development.md
@@ -69,9 +69,7 @@ Create a pull request that:
 
 1. Adds release notes to `CHANGELOG.md`.
 
-2. Updates the `VERSION` constant in `pyproject.toml`.
-
-3. Updates the `__version__` constant in `xocto/__init__.py`, following the
+2. Updates the `VERSION` constant in `pyproject.toml`, following the
    [semver.org](https://semver.org/) specification.
 
 Commit these changes in a single commit with subject matching

--- a/xocto/__init__.py
+++ b/xocto/__init__.py
@@ -1,1 +1,4 @@
-__version__ = "4.8.0"
+import importlib.metadata
+
+
+__version__ = importlib.metadata.version("xocto")


### PR DESCRIPTION
Bumps version to 4.9.0.

Populates `xocto.__version__` using package metadata.