### PR TITLE
Add utility fnctions to convert date/time ranges

### DIFF
--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -898,3 +898,54 @@ class TestFiniteDateRange:
             )
             union = range | other
             assert union == range
+
+
+class TestAsFiniteDatetimePeriods:
+    def test_converts(self):
+        actually_finite_range = ranges.DatetimeRange(
+            datetime.datetime(2020, 1, 1),
+            datetime.datetime(2020, 1, 5),
+        )
+
+        results = list(
+            ranges.as_finite_datetime_periods(
+                [actually_finite_range],
+            )
+        )
+
+        assert results == [
+            ranges.FiniteDatetimeRange(
+                actually_finite_range.start,
+                actually_finite_range.end,
+            )
+        ]
+
+    def test_errors_if_infinite(self):
+        with pytest.raises(ValueError) as exc_info:
+            ranges.as_finite_datetime_periods(
+                [
+                    ranges.DatetimeRange(datetime.datetime(2020, 1, 1), None),
+                ],
+            )
+
+        assert "Period is not finite at start or end or both" in str(exc_info.value)
+
+
+class TestAsDatePeriods:
+    def test_converts(self):
+        dt_range = ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 1),
+            datetime.datetime(2020, 1, 5),
+        )
+
+        results = ranges.as_date_periods(
+            [dt_range],
+            date_converter=lambda dt: dt.date(),
+        )
+
+        assert results == [
+            ranges.FiniteDateRange(
+                datetime.date(2020, 1, 1),
+                datetime.date(2020, 1, 4),
+            )
+        ]

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -440,10 +440,6 @@ class Range(Generic[T]):
         return self.is_left_finite() and self.is_right_finite()
 
 
-# Type aliases for common range types
-DatetimeRange = Range[datetime.datetime]
-
-
 class FiniteRange(Range[T]):
     """
     A FiniteRange represents a range that MUST have finite endpoints (i.e. they cannot be None).
@@ -488,6 +484,11 @@ class HalfFiniteRange(Range[T]):
 
     def __and__(self, other: Range[T]) -> Optional["HalfFiniteRange[T]"]:
         return self.intersection(other)
+
+
+# Type aliases for common range types
+DatetimeRange = Range[datetime.datetime]
+HalfFiniteDatetimeRange = HalfFiniteRange[datetime.datetime]
 
 
 class RangeSet(Generic[T]):

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -7,6 +7,7 @@ import itertools
 import operator
 from typing import (
     Any,
+    Callable,
     Generic,
     Iterable,
     Iterator,
@@ -945,3 +946,56 @@ def any_overlapping(ranges: Iterable[Range[T]]) -> bool:
             return True
         range_set.add(range)
     return False
+
+
+def as_finite_datetime_periods(
+    periods: Iterable[HalfFiniteDatetimeRange | DatetimeRange],
+) -> Sequence[FiniteDatetimeRange]:
+    """
+    Casts the given date/time periods as finite periods.
+
+    This is useful when working with potentially infinite ranges that are
+    known to be finite e.g. due to intersection with a finite range.
+
+    Raises:
+        ValueError: If one or more periods is not finite.
+    """
+    finite_periods = []
+
+    for period in periods:
+        if period.start is None or period.end is None:
+            raise ValueError("Period is not finite at start or end or both")
+
+        finite_periods += [FiniteDatetimeRange(period.start, period.end)]
+
+    return finite_periods
+
+
+def as_date_periods(
+    periods: Iterable[FiniteDatetimeRange],
+    *,
+    date_converter: Callable[[datetime.datetime], datetime.date],
+) -> Sequence[FiniteDateRange]:
+    """
+    Converts the given date/time periods to date periods.
+
+    The given date converter is used to decide what date to ascribe to a
+    given date/time, since we lose timezone info in this conversion.
+
+    We need to decide what to do with partial days at the start and end:
+
+    - The period start will be treated as a whole day and included, even if
+    the start time is part way through the day.
+
+    - The period end date will be ignored and excluded, even if most of the
+    day is covered; the previous day is the end*.
+
+    *Date ranges are inclusive at their ends.
+    """
+    return [
+        FiniteDateRange(
+            date_converter(period.start),
+            date_converter(period.end) - datetime.timedelta(days=1),
+        )
+        for period in periods
+    ]


### PR DESCRIPTION
Needed for https://github.com/octoenergy/kraken-core/pull/116552

This adds two new functions:

- as_finite_datetime_periods
- as_date_periods

Together they can be used to convert (finite) date/time periods to finite
date periods, which is useful where source data is available at time
granularity but needs to be used in date-oriented code.