### PR TITLE
Add "as_finite_datetime_periods" fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add "as_finite_datetime_periods" fn [#134](https://github.com/octoenergy/xocto/pull/134)
+
 ## v4.9.2 - 2023-12-07
 
 - Add HalfFiniteRangeSet class to better support working with sets of such ranges [#130](https://github.com/octoenergy/xocto/pull/130)

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -898,3 +898,34 @@ class TestFiniteDateRange:
             )
             union = range | other
             assert union == range
+
+
+class TestAsFiniteDatetimePeriods:
+    def test_converts(self):
+        actually_finite_range = ranges.DatetimeRange(
+            datetime.datetime(2020, 1, 1),
+            datetime.datetime(2020, 1, 5),
+        )
+
+        results = list(
+            ranges.as_finite_datetime_periods(
+                [actually_finite_range],
+            )
+        )
+
+        assert results == [
+            ranges.FiniteDatetimeRange(
+                actually_finite_range.start,
+                actually_finite_range.end,
+            )
+        ]
+
+    def test_errors_if_infinite(self):
+        with pytest.raises(ValueError) as exc_info:
+            ranges.as_finite_datetime_periods(
+                [
+                    ranges.DatetimeRange(datetime.datetime(2020, 1, 1), None),
+                ],
+            )
+
+        assert "Period is not finite at start or end or both" in str(exc_info.value)

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -440,10 +440,6 @@ class Range(Generic[T]):
         return self.is_left_finite() and self.is_right_finite()
 
 
-# Type aliases for common range types
-DatetimeRange = Range[datetime.datetime]
-
-
 class FiniteRange(Range[T]):
     """
     A FiniteRange represents a range that MUST have finite endpoints (i.e. they cannot be None).
@@ -488,6 +484,11 @@ class HalfFiniteRange(Range[T]):
 
     def __and__(self, other: Range[T]) -> Optional["HalfFiniteRange[T]"]:
         return self.intersection(other)
+
+
+# Type aliases for common range types
+DatetimeRange = Range[datetime.datetime]
+HalfFiniteDatetimeRange = HalfFiniteRange[datetime.datetime]
 
 
 class RangeSet(Generic[T]):

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -945,3 +945,26 @@ def any_overlapping(ranges: Iterable[Range[T]]) -> bool:
             return True
         range_set.add(range)
     return False
+
+
+def as_finite_datetime_periods(
+    periods: Iterable[HalfFiniteDatetimeRange | DatetimeRange],
+) -> Sequence[FiniteDatetimeRange]:
+    """
+    Casts the given date/time periods as finite periods.
+
+    This is useful when working with potentially infinite ranges that are
+    known to be finite e.g. due to intersection with a finite range.
+
+    Raises:
+        ValueError: If one or more periods is not finite.
+    """
+    finite_periods = []
+
+    for period in periods:
+        if period.start is None or period.end is None:
+            raise ValueError("Period is not finite at start or end or both")
+
+        finite_periods += [FiniteDatetimeRange(period.start, period.end)]
+
+    return finite_periods


### PR DESCRIPTION
Needed for octoenergy/kraken-core#116552

This can be used as part of a broader conversion of (finite)
date / time periods to finite date periods - the date part of
the conversion is too simple / specific to add here as well.