### PR TITLE
Display the docs badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,9 @@ CI status:
 
 [![CircleCI](https://circleci.com/gh/octoenergy/xocto/tree/main.svg?style=svg)](https://circleci.com/gh/octoenergy/xocto/tree/main)
 
+Docs status:
+
+[![Documentation Status](https://readthedocs.org/projects/xocto/badge/?version=latest)](https://xocto.readthedocs.io/en/latest/?badge=latest)
+
 - PyPI detail page: <https://pypi.python.org/pypi/xocto>
 - Documentation: <https://xocto.readthedocs.io/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ dev = [
 docs = [
   "Sphinx==4.5.0",
   "myst-parser==0.18.1",
+  "sphinxcontrib-serializinghtml==1.1.5",
+  "sphinx-rtd-theme==1.1.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Prior to this change, the README did not display the docs badge, and the docs had been broken for months.

This change displays the build status on the README so it's more obvious when the doc build is failing.