### PR TITLE
Bump version to v4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## v4.10.0 - 2024-03-05
+
+- Updated dev dependencies like ruff, pytest, and mypy [#138](https://github.com/octoenergy/xocto/pull/138)
+- Updated doc dependencies to fix the build [#139](https://github.com/octoenergy/xocto/pull/139)
+- Added a new module `xocto.fields.postgres.ranges` to provide range fields that work with the `Range` classes from `xocto.ranges` [#136](https://github.com/octoenergy/xocto/pull/136)
+    - Tests now depend on postgres and psycopg2
+- Doc site should now build again correctly
+
 ## v4.9.3 - 2024-01-16
 
 - Add "as_finite_datetime_periods" fn [#134](https://github.com/octoenergy/xocto/pull/134)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xocto"
-version = "4.9.3"
+version = "4.10.0"
 requires-python = ">=3.9"
 description = "Kraken Technologies Python service utilities"
 readme = "README.md"


### PR DESCRIPTION
## v4.10.0 - 2024-03-05

- Updated dev dependencies like ruff, pytest, and mypy [#138](https://github.com/octoenergy/xocto/pull/138)
- Updated doc dependencies to fix the build [#139](https://github.com/octoenergy/xocto/pull/139)
- Added a new module `xocto.fields.postgres.ranges` to provide range fields that work with the `Range` classes from `xocto.ranges` [#136](https://github.com/octoenergy/xocto/pull/136)
    - Tests now depend on postgres and psycopg2