### PR TITLE
Improve sphinx configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,15 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import pathlib
 import sys
+from datetime import datetime
 
 import django
+
+# Use pip-vendored tomli so we can read pyproject.toml
+# When we upgrade Python to 3.11 we can use tomllib directly
+from pip._vendor import tomli
 
 
 sys.path.insert(0, os.path.abspath(".."))  # for discovery of project modules
@@ -26,11 +32,13 @@ django.setup()
 # -- Project information -----------------------------------------------------
 
 project = "xocto"
-copyright = "2023, Kraken Tech"
+copyright = f"{datetime.now().year}, Kraken Tech"
 author = "Kraken Tech"
 
-# The full version, including alpha/beta/rc tags
-release = "2.3.0"
+# Fetch the version from pyproject.toml
+path = pathlib.Path(__file__).parent / ".." / "pyproject.toml"
+pyproject = tomli.loads(path.read_text())
+release = pyproject["project"]["version"]
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,10 @@ dev = [
   "wheel==0.38.4",
 ]
 docs = [
-  "Sphinx==4.5.0",
-  "myst-parser==0.18.1",
-  "sphinxcontrib-serializinghtml==1.1.5",
-  "sphinx-rtd-theme==1.1.1",
+  "Sphinx==7.2.6",
+  "myst-parser==2.0.0",
+  "sphinxcontrib-serializinghtml==1.1.10",
+  "sphinx-rtd-theme==2.0.0",
 ]
 
 [project.urls]
@@ -168,7 +168,7 @@ ignore = [
 # Allow unused imports in __init__ files as these are convenience imports
 "**/__init__.py" = [ "F401" ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 lines-after-imports = 2
 section-order = [
     "future",
@@ -179,7 +179,7 @@ section-order = [
     "local-folder",
 ]
 
-[tool.ruff.isort.sections]
+[tool.ruff.lint.isort.sections]
 "project" = [
     "xocto",
     "tests",


### PR DESCRIPTION
This PR does the following:

1. Update Sphinx package versions so docs actually build locally and on ReadTheDocs
2. Update copyrights upon build
3. Updates the xocto version in Sphinx upon build

Thanks to the indomitable @jarshwah for flagging this needed to be done. :power: