### PR TITLE
Make `Range` instances somewhat immutable

### DIFF
--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -47,6 +47,10 @@ class TestRange:
             0, 2, boundaries=ranges.RangeBoundaries.EXCLUSIVE_INCLUSIVE
         ) == ranges.Range(0, 2, boundaries="(]")
 
+    def test_does_not_have_instance_dictionary(self):
+        r = ranges.Range(0, 2, boundaries=ranges.RangeBoundaries.EXCLUSIVE_INCLUSIVE)
+        assert not hasattr(r, "__dict__")
+
     @pytest.mark.parametrize(
         "start,end,boundaries",
         [
@@ -455,6 +459,23 @@ class TestRangeSet:
         rangeset = _rangeset_from_string(rangeset_str)
         other_rangeset = _rangeset_from_string(other_rangeset_str)
         assert str(rangeset - other_rangeset) == expected_result_str
+
+
+class TestHalfFiniteRange:
+    def test_creation_uses_expected_defaults(self):
+        r = ranges.HalfFiniteRange(0)
+        assert 0 == r.start
+        assert r.end is None
+        assert ranges.RangeBoundaries.INCLUSIVE_EXCLUSIVE == r.boundaries
+
+    def test_creation(self):
+        r = ranges.HalfFiniteRange(1, 2)
+        assert 1 == r.start
+        assert 2 == r.end
+
+    def test_does_not_have_instance_dictionary(self):
+        r = ranges.HalfFiniteRange(0, 2)
+        assert not hasattr(r, "__dict__")
 
 
 ONE_DAY = datetime.timedelta(days=1)

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -47,6 +47,18 @@ class TestRange:
             0, 2, boundaries=ranges.RangeBoundaries.EXCLUSIVE_INCLUSIVE
         ) == ranges.Range(0, 2, boundaries="(]")
 
+    def test_is_immutable(self):
+        r = ranges.Range(0, 2, boundaries=ranges.RangeBoundaries.EXCLUSIVE_INCLUSIVE)
+        with pytest.raises(AttributeError, match="Can't set attributes"):
+            r.start = 1
+
+    def test_additional_attributes_cant_be_created(self):
+        r = ranges.Range(0, 2, boundaries=ranges.RangeBoundaries.EXCLUSIVE_INCLUSIVE)
+        with pytest.raises(
+            AttributeError, match="'Range' object has no attribute 'something_else'"
+        ):
+            r.something_else = 1
+
     def test_does_not_have_instance_dictionary(self):
         r = ranges.Range(0, 2, boundaries=ranges.RangeBoundaries.EXCLUSIVE_INCLUSIVE)
         assert not hasattr(r, "__dict__")

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -143,7 +143,7 @@ class Range(Generic[T]):
         None
     """
 
-    __slots__ = [
+    __slots__ = (
         "start",
         "end",
         "boundaries",
@@ -151,7 +151,15 @@ class Range(Generic[T]):
         "_is_left_inclusive",
         "_is_right_exclusive",
         "_is_right_inclusive",
-    ]
+    )
+
+    start: Optional[T]
+    end: Optional[T]
+    boundaries: RangeBoundaries
+    _is_left_exclusive: bool
+    _is_left_inclusive: bool
+    _is_right_exclusive: bool
+    _is_right_inclusive: bool
 
     def __init__(
         self,
@@ -448,6 +456,9 @@ class FiniteRange(Range[T]):
     and then skip checking if the endpoints are None.
     """
 
+    __slots__ = ()
+
+    # Redefine types in base class
     start: T
     end: T
 
@@ -473,8 +484,13 @@ class HalfFiniteRange(Range[T]):
     HalfFiniteRange.
     """
 
+    __slots__ = ()
+
+    # Redefine types in base class
     start: T
-    boundaries = RangeBoundaries.INCLUSIVE_EXCLUSIVE
+
+    def __init__(self, start: T, end: Optional[T] = None):
+        super().__init__(start, end, boundaries=RangeBoundaries.INCLUSIVE_EXCLUSIVE)
 
     def intersection(self, other: Range[T]) -> Optional["HalfFiniteRange[T]"]:
         """
@@ -780,6 +796,8 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
     of time.
     """
 
+    __slots__ = ()
+
     def __init__(self, start: datetime.datetime, end: datetime.datetime):
         """
         Force the boundaries of the range to be [).
@@ -824,6 +842,8 @@ class FiniteDateRange(FiniteRange[datetime.date]):
     This subclass is a helper for a common usecase for ranges - representing finite intervals
     of whole days.
     """
+
+    __slots__ = ()
 
     def __init__(self, start: datetime.date, end: datetime.date):
         """


### PR DESCRIPTION
This PR addresses two problems with `Range`.

1. Attributes of `Range` instances can be set, bypassing validation and violating class invariants:

    ```pycon
    >>> from xocto import ranges
    >>> r = ranges.Range(0, 1)
    >>> r.start = 2
    >>> r.boundaries = '😱'
    ```

2. Additional attributes can be set on instances of classes derived from `Range`

    `Range` uses `__slots__`, which prevents creation of instance dictionaries. Classes derived from `Range` do not have `__slots__ = ()`, which means that instance dictionaries are created:

    ```pycon
    >>> from xocto import localtime
    >>> r = ranges.FiniteDatetimeRange(localtime.datetime(2000, 1, 1), localtime.datetime(2000, 1, 3))
    >>> r.some_other_thing = "I shouldn't be here"
    >>> r.__dict__
    {'some_other_thing': "I shouldn't be here"}
    ```

Fix these problems:

* add `__slots__ = ()` to classes that have `Range` as a base class (preventing creation of instance dicts),
* add `Range.__setattr__` to raise `AttributeError`, and
* alter `Range.__init__` to use the same `object.__setattr__` [trick as `attrs`](https://www.attrs.org/en/stable/init.html#post-init) to set attributes during initialisation. 
