### PR TITLE
Autodiscover packages to be included in the artefact

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,9 @@ changelog = "https://github.com/octoenergy/xocto/blob/main/CHANGELOG.md"
 documentation = "https://xocto.readthedocs.io"
 issues = "https://github.com/octoenergy/xocto/issues"
 
-[tool.setuptools]
-packages = ["xocto", "xocto.events", "xocto.storage"]
+[tool.setuptools.packages.find]
+include = ["xocto*"]
+namespaces = false
 
 [tool.setuptools.package-data]
 "xocto" = ["py.typed"]


### PR DESCRIPTION
Prior to this change, each package needed to be separately listed in pyproject.toml, meaning any new packages (sub-folders) would not be included in the distribution without also updating pyproject.toml.

This change levereges setuptools to autodiscover packages to be included within the xocto root package.

Specifically, this change now makes `xocto.fields` importable as it's not currently present in the 4.10.0 distribution.