### PR TITLE
Split xocto.types into a separate package

### DIFF
--- a/docs/xocto/types.md
+++ b/docs/xocto/types.md
@@ -10,12 +10,13 @@ Utility types to save having to redefine the same things over and over.
 
 ```{eval-rst}
 
-.. autodata:: xocto.types.Model
-.. autodata:: xocto.types.ForeignKey
-.. autodata:: xocto.types.OneToOneField
-.. autodata:: xocto.types.OptionalForeignKey
-.. autodata:: xocto.types.Choices
-.. autodata:: xocto.types.T
+.. autodata:: xocto.types.django.Model
+.. autodata:: xocto.types.django.ForeignKey
+.. autodata:: xocto.types.django.OneToOneField
+.. autodata:: xocto.types.django.OptionalForeignKey
+.. autodata:: xocto.types.django.Choices
+.. autodata:: xocto.types.generic.T
+.. autodata:: xocto.types.generic.Comparable
 ```
 
 ## API Reference
@@ -29,5 +30,3 @@ Utility types to save having to redefine the same things over and over.
    :undoc-members:
    :show-inheritance:
 ```
-
-

--- a/xocto/numbers.py
+++ b/xocto/numbers.py
@@ -4,7 +4,7 @@ import decimal
 import random
 from typing import TypeVar
 
-from . import types
+from xocto.types import generic
 
 
 def quantise(
@@ -100,11 +100,11 @@ T = TypeVar("T")
 
 
 def clip_to_range(
-    val: types.Comparable[T],
+    val: generic.Comparable[T],
     *,
-    minval: types.Comparable[T],
-    maxval: types.Comparable[T],
-) -> types.Comparable[T]:
+    minval: generic.Comparable[T],
+    maxval: generic.Comparable[T],
+) -> generic.Comparable[T]:
     """
     Clip the value to the min and max values given.
 

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -19,7 +19,7 @@ from typing import (
     cast,
 )
 
-from . import types
+from xocto.types import generic
 
 
 class RangeBoundaries(enum.Enum):
@@ -44,7 +44,7 @@ class RangeBoundaries(enum.Enum):
         }[(left_exclusive, right_exclusive)]
 
 
-T = TypeVar("T", bound=types.Comparable)  # type: ignore[type-arg]
+T = TypeVar("T", bound=generic.Comparable)  # type: ignore[type-arg]
 
 
 @functools.total_ordering

--- a/xocto/types/django.py
+++ b/xocto/types/django.py
@@ -1,8 +1,4 @@
-"""
-Utility types to save having to redefine the same things over and over.
-"""
-
-from typing import Any, Generic, Protocol, Tuple, TypeVar, Union
+from typing import Generic, Tuple, TypeVar, Union
 
 from django.contrib.auth import models as auth_models
 from django.db import models
@@ -33,26 +29,6 @@ OptionalOneToOneField = Union[
 
 # A type variable to describe the Django model choices kwarg
 Choices = Tuple[Tuple[str, str], ...]
-
-
-T = TypeVar("T", covariant=True)
-
-
-class Comparable(Protocol[T]):
-    """
-    Just a very basic way of describing an object that can be compared to another using some
-    basic operations.
-    """
-
-    def __eq__(self, other: Any) -> bool: ...
-
-    def __lt__(self, other: Any) -> bool: ...
-
-    def __le__(self, other: Any) -> bool: ...
-
-    def __gt__(self, other: Any) -> bool: ...
-
-    def __ge__(self, other: Any) -> bool: ...
 
 
 class AuthenticatedRequest(HttpRequest, Generic[User]):

--- a/xocto/types/generic.py
+++ b/xocto/types/generic.py
@@ -1,0 +1,21 @@
+from typing import Any, Protocol, TypeVar
+
+
+T = TypeVar("T", covariant=True)
+
+
+class Comparable(Protocol[T]):
+    """
+    Just a very basic way of describing an object that can be compared to another using some
+    basic operations.
+    """
+
+    def __eq__(self, other: Any) -> bool: ...
+
+    def __lt__(self, other: Any) -> bool: ...
+
+    def __le__(self, other: Any) -> bool: ...
+
+    def __gt__(self, other: Any) -> bool: ...
+
+    def __ge__(self, other: Any) -> bool: ...

--- a/xocto/types/generic.py
+++ b/xocto/types/generic.py
@@ -6,8 +6,7 @@ T = TypeVar("T", covariant=True)
 
 class Comparable(Protocol[T]):
     """
-    Just a very basic way of describing an object that can be compared to another using some
-    basic operations.
+    A way of describing an object that can be compared to another using some basic operations.
     """
 
     def __eq__(self, other: Any) -> bool: ...


### PR DESCRIPTION
Prior to this change, all types were in a single file, including the Django specific types that depend on Django itself.

This change creates a new types sub-package and splits it into separate modules. All of the types that depend on Django are now in a separate module.

Now xocto.ranges and xocto.numbers can be imported without having to install and configure Django.

As this is a breaking change, it'll need a major version number update.