### PR TITLE
The release to pypi action now targets the tag ref

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
Prior to this change, we'd attempt to release from the master branch, no matter which actual tag was pushed.