### PR TITLE
Begin version 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## v5.0.0 - Unreleased
+
+- [Breaking] Range types are now (mostly) immutable [#142](https://github.com/octoenergy/xocto/pull/142)
+    - start, end, and bounds can no longer be modified after creation
+- [Breaking] The `types` module is now split into a package containing `types.generic` and `types.django` [#144](https://github.com/octoenergy/xocto/pull/144)
+    - `xocto.numbers` and `xocto.ranges` can now be imported without configuring Django
+
+
 ## v4.10.2 - 2024-03-13
 
 - Yanked v4.10.1 due to unintentional inclusion of breaking changes. This release is identical to v4.10.1, but with the breaking changes from [#142](https://github.com/octoenergy/xocto/pull/142) removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v4.10.2 - 2024-03-13
+
+- Yanked v4.10.1 due to unintentional inclusion of breaking changes. This release is identical to v4.10.1, but with the breaking changes from [#142](https://github.com/octoenergy/xocto/pull/142) removed.
+
+
 ## v4.10.1 - 2024-03-12
 
 - Updated build config to automatically include sub-packages [#143](https://github.com/octoenergy/xocto/pull/143)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xocto"
-version = "4.10.1"
+version = "4.10.2"
 requires-python = ">=3.9"
 description = "Kraken Technologies Python service utilities"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xocto"
-version = "4.10.2"
+version = "5.0.0"
 requires-python = ">=3.9"
 description = "Kraken Technologies Python service utilities"
 readme = "README.md"


### PR DESCRIPTION
Also backports the release notes for v4.10.2 which is pending release.

Now that main has breaking changes merged in, we proactively bump the major version and begin release notes. Any changes that need to be applied to the v4 series will need to branch appropriately.