### PR TITLE
Add latest changes action

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -1,0 +1,27 @@
+name: Latest Changes
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+  # For manually triggering it
+  workflow_dispatch:
+    inputs:
+      number:
+        description: PR number
+        required: true
+
+jobs:
+  latest-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ACTION_TOKEN }}      
+      - uses: tiangolo/latest-changes@0.2.1
+        with:
+          token: ${{ secrets.ACTION_TOKEN }}
+          latest_changes_file: CHANGELOG.md
+          latest_changes_header: '## Unreleased'

--- a/docs/xocto/development.md
+++ b/docs/xocto/development.md
@@ -67,7 +67,7 @@ where:
 
 Create a pull request that:
 
-1. Adds release notes to `CHANGELOG.md`.
+1. Moves the latest unreleased changes in `CHANGELOG.md` to the next version number.
 
 2. Update the `version` constant in `pyproject.toml`, following the
    [semver.org](https://semver.org/) specification.


### PR DESCRIPTION
The [latest-changes](https://github.com/tiangolo/latest-changes) GitHub action allows us to automate our change log generation, including the related PR and author as a byproduct. You can see an example of the difference [here](https://github.com/pydanny/fastapi-blog/blob/main/changelog.md#changelog). In this example:

1. The first bullet was generated using latest-changes and links to the PR and author
2. The following bullets were handcraft, note the lack of connectivity and consistency

An interesting feature of this tool is it can be [manually triggered on historical PRs](https://github.com/tiangolo/latest-changes#existing-prs---running-manually). So if we want to rewrite and clean up the history of this tool, this makes it possible to do so.

Note: Before this tool functions, it requires the create of an `ACTION_TOKEN` secret for the repo that has push permissions. I do not have the authority to do so. 