### PR TITLE
Implement the copy and deepcopy protocol for Range

### DIFF
--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import datetime
 import re
 from typing import Any
@@ -964,6 +965,19 @@ class TestAsFiniteDatetimePeriods:
             )
 
         assert "Period is not finite at start or end or both" in str(exc_info.value)
+
+
+@pytest.mark.xfail(reason="Regression test")
+class TestRangeCopy:
+    def test_range_copy(self):
+        r1 = ranges.Range(1, 2)
+        r2 = copy.copy(r1)
+        assert r1 == r2
+
+    def test_range_deepcopy(self):
+        r1 = ranges.Range(1, 2)
+        r2 = copy.deepcopy(r1)
+        assert r1 == r2
 
 
 def _rangeset_from_string(rangeset_str: str) -> ranges.RangeSet[int]:

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -967,7 +967,6 @@ class TestAsFiniteDatetimePeriods:
         assert "Period is not finite at start or end or both" in str(exc_info.value)
 
 
-@pytest.mark.xfail(reason="Regression test")
 class TestRangeCopy:
     def test_range_copy(self):
         r1 = ranges.Range(1, 2)
@@ -978,6 +977,23 @@ class TestRangeCopy:
         r1 = ranges.Range(1, 2)
         r2 = copy.deepcopy(r1)
         assert r1 == r2
+
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            ranges.Range(1, 2),
+            ranges.FiniteDateRange(
+                datetime.date(2000, 1, 1), datetime.date(2000, 1, 2)
+            ),
+            ranges.FiniteDatetimeRange(
+                datetime.datetime(2000, 1, 1), datetime.datetime(2000, 1, 2)
+            ),
+            ranges.HalfFiniteRange(1, 2),
+        ],
+        ids=("range", "date_range", "datetime_range", "half_finite_range"),
+    )
+    def test_copies(self, obj):
+        assert obj == copy.copy(obj) == copy.deepcopy(obj)
 
 
 def _rangeset_from_string(rangeset_str: str) -> ranges.RangeSet[int]:

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -285,6 +285,22 @@ class Range(Generic[T]):
         """
         return self._is_inside_left_bound(item) and self._is_inside_right_bound(item)
 
+    def __copy__(self) -> Range[T]:
+        """
+        Return self.
+
+        Ranges are immutable, so there is no need to create a copy.
+        """
+        return self
+
+    def __deepcopy__(self, memo: dict[Any, Any]) -> Range[T]:
+        """
+        Return self.
+
+        Ranges are immutable, so there is no need to create a copy.
+        """
+        return self
+
     def _is_inside_left_bound(self, item: T) -> bool:
         """
         Check if the provided item is inside our left bound.


### PR DESCRIPTION
Now that ranges are immutable, attempting to copy a range type would throw an error. This change implements the copy protocols by returning `self` directly. Since these are immutable instances there is no need to create a new copy. This is consistent with python itself, which will return functions directly rather than attempt to copy them.