### PR TITLE
Add LtreeField model field

### DIFF
--- a/tests/fields/postgres/test_ltree.py
+++ b/tests/fields/postgres/test_ltree.py
@@ -1,0 +1,67 @@
+import pytest
+
+from tests.models import models
+
+
+pytestmark = pytest.mark.django_db
+
+
+class TestLtreeField:
+    def test_get_descendants_no_children(self):
+        root = models.TreeModel.objects.create(parent=None, path="root")
+
+        results = models.TreeModel.objects.filter(path__ancestor=root.path)
+
+        # The root node is considered to be a descendant of itself
+        assert set(results) == {root}
+
+    def test_get_descendants(self):
+        root = models.TreeModel.objects.create(parent=None, path="root")
+        child = models.TreeModel.objects.create(parent=root, path="root.child")
+        grandchild = models.TreeModel.objects.create(
+            parent=root, path="root.child.grandchild"
+        )
+
+        results = models.TreeModel.objects.filter(path__ancestor=root.path)
+
+        # The root node is considered to be a descendant of itself
+        assert set(results) == {root, child, grandchild}
+
+        results = models.TreeModel.objects.filter(path__ancestor=child.path)
+
+        # The root node should not appear as a descendant of the child
+        assert set(results) == {child, grandchild}
+
+    def test_get_descendants_with_siblings(self):
+        root = models.TreeModel.objects.create(parent=None, path="root")
+        child1 = models.TreeModel.objects.create(parent=root, path="root.child1")
+        child2 = models.TreeModel.objects.create(parent=root, path="root.child2")
+
+        results = models.TreeModel.objects.filter(path__ancestor=root.path)
+
+        assert set(results) == {root, child1, child2}
+
+    def test_get_ancestors_none(self):
+        root = models.TreeModel.objects.create(parent=None, path="root")
+
+        results = models.TreeModel.objects.filter(path__descendant=root.path)
+
+        # The grandchild node is considered to be an ancestor of itself
+        assert set(results) == {root}
+
+    def test_get_ancestors(self):
+        root = models.TreeModel.objects.create(parent=None, path="root")
+        child = models.TreeModel.objects.create(parent=root, path="root.child")
+        grandchild = models.TreeModel.objects.create(
+            parent=root, path="root.child.grandchild"
+        )
+
+        results = models.TreeModel.objects.filter(path__descendant=grandchild.path)
+
+        # The grandchild node is considered to be an ancestor of itself
+        assert set(results) == {root, child, grandchild}
+
+        results = models.TreeModel.objects.filter(path__descendant=child.path)
+
+        # The grandchild should not appear as an ancestor of the child
+        assert set(results) == {root, child}

--- a/tests/models/models.py
+++ b/tests/models/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from xocto.fields.postgres import ltree
 from xocto.fields.postgres import ranges as range_fields
 
 
@@ -18,3 +19,8 @@ class HalfFiniteDateTimeRangeModel(models.Model):
     half_finite_datetime_range_nullable = range_fields.HalfFiniteDateTimeRangeField(
         null=True
     )
+
+
+class TreeModel(models.Model):
+    parent = models.ForeignKey("self", null=True, on_delete=models.SET_NULL)
+    path = ltree.LtreeField()

--- a/xocto/fields/postgres/ltree.py
+++ b/xocto/fields/postgres/ltree.py
@@ -1,0 +1,104 @@
+"""
+This module's approach is inspired by
+
+https://github.com/peopledoc/django-ltree-demo
+
+One difference is that the <@ and @> operators are reversed compared to the
+demo, since this makes for more natural querying e.g.
+
+    filter(path__ancestor=my_path)
+
+returns the *descendants* of my_path (the demo uses path_descendant for this).
+"""
+
+from django.db import models
+
+
+class LtreeField(models.TextField):
+    """
+    LtreeField provides a django model field representation of the ltree type.
+
+    The ltree extension must be installed in the database for this field to work e.g.
+
+        CREATE EXTENSION IF NOT EXISTS ltree
+
+    It is recommended to create a GiST index over the ltree field in order to
+    optimize the ancestor/descendant look ups.
+
+    More information can be found in the PostgreSQL documentation:
+
+    https://www.postgresql.org/docs/current/ltree.html
+    """
+
+    description = "ltree"
+
+    def db_type(self, connection):
+        return "ltree"
+
+
+class Ancestor(models.Lookup):
+    """
+    Ancestor provides a lookup for querying by an ltree path's ancestor.
+
+    For example, if the model is defined as
+
+        class Foo(models.Model):
+            path = LtreeField
+
+    and
+
+        bar = Foo(path="my_path")
+
+    then we can query as
+
+        Foo.objects.filter(path__ancestor=bar.path)
+
+    to obtain all of the instances of Foo that have bar as their ancestor i.e.
+    bar's descendants.
+
+    The relationship is reflexive i.e. bar is its own descendant.
+    """
+
+    lookup_name = "ancestor"
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return "%s <@ %s" % (lhs, rhs), params
+
+
+class Descendant(models.Lookup):
+    """
+    Descendant provides a lookup for querying by an ltree path's descendant.
+
+    For example, if the model is defined as
+
+        class Foo(models.Model):
+            path = LtreeField
+
+    and
+
+        bar = Foo(path="my_path")
+
+    then we can query as
+
+        Foo.objects.filter(path__descendant=bar.path)
+
+    to obtain all of the instances of Foo that have bar as a descendant i.e.
+    bar's ancestors.
+
+    The relationship is reflexive i.e. bar is its own ancestor.
+    """
+
+    lookup_name = "descendant"
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return "%s @> %s" % (lhs, rhs), params
+
+
+LtreeField.register_lookup(Ancestor)
+LtreeField.register_lookup(Descendant)


### PR DESCRIPTION
This model field provides the basic toolkit for representing tree-like
data-structures within a PostgreSQL database, using the `ltree`
extension. It is not intended to be a complete framework for providing
this functionality, but instead a simple way to bring the `ltree` data
type into a Django model.

More on this extension can be found in the Postgres documentation:

https://www.postgresql.org/docs/current/ltree.html

The approach takes inspiration from the that outlined in

https://github.com/peopledoc/django-ltree-demo.

One difference is that the <@ and @> operators are reversed compared to
the demo, since this makes for more natural querying e.g.

    filter(path__ancestor=my_path)

returns the *descendants* of my_path (the demo uses path_descendant for
this).
