### PR TITLE
Bump version to v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v5.1.0 - 2024-07-03
+
+- Add `ranges.iterate_over_months` function [#163](https://github.com/octoenergy/xocto/pull/163)
+
 ## v5.0.1 - 2024-06-18
 
 - Implements `__copy__` and `__deepcopy__` on Range types [#160](https://github.com/octoenergy/xocto/pull/160/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xocto"
-version = "5.0.1"
+version = "5.1.0"
 requires-python = ">=3.9"
 description = "Kraken Technologies Python service utilities"
 readme = "README.md"


### PR DESCRIPTION
## v5.1.0 - 2024-07-03

- Add `ranges.iterate_over_months` function [#163](https://github.com/octoenergy/xocto/pull/163)