### PR TITLE
Rename pact_service parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- [Breaking] Use parameter object for passing options to `pact_service`.
+  Rename parameter `pact_version` to `consumer_version`.
+  [#167](https://github.com/octoenergy/xocto/pull/167)
+
 ## v5.1.0 - 2024-07-03
 
 - Add `ranges.iterate_over_months` function [#163](https://github.com/octoenergy/xocto/pull/163)

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -1,0 +1,26 @@
+from xocto import pact_testing
+
+
+def test_pact_service():
+    options = pact_testing.PactOptions(
+        broker_url="https://pact-broker.example.com",
+        broker_username="username",
+        broker_password="password",
+        consumer_name="consumer_name",
+        consumer_version="1.0.0",
+        provider_name="provider_name",
+        log_path="/tmp/pact/",
+    )
+    pact_service = pact_testing.pact_service(
+        options=options,
+        publish_to_broker=True,
+    )
+    assert pact_service.broker_base_url == "https://pact-broker.example.com"
+    assert pact_service.broker_username == "username"
+    assert pact_service.broker_password == "password"
+    assert pact_service.provider.name == "provider_name"
+    assert pact_service.consumer.name == "consumer_name"
+    assert pact_service.consumer.version == "1.0.0"
+    assert pact_service.publish_to_broker is True
+    assert pact_service.pact_dir == "/tmp/pact/"
+    assert pact_service.log_dir == "/tmp/pact/"

--- a/xocto/pact_testing.py
+++ b/xocto/pact_testing.py
@@ -35,12 +35,12 @@ def pact_service(
     pact_broker_password: str,
     pact_consumer_name: str,
     pact_provider_name: str,
-    pact_version: str,
+    pact_consumer_version: str,
     publish_to_broker: bool,
     pact_log_path: str = "pact_logs",
 ) -> pact.Pact:
     service = pact.Consumer(
-        name=pact_consumer_name, tag_with_git_branch=True, version=pact_version
+        name=pact_consumer_name, tag_with_git_branch=True, version=pact_consumer_version
     ).has_pact_with(
         pact.Provider(pact_provider_name),
         publish_to_broker=publish_to_broker,


### PR DESCRIPTION
A pact version refers to the version of a pact file and is handled by the pact framework internally. Referring to the application version reference as `pact_version` can create confusion. For a long time, [we defaulted to a consumer version of `latest` in kraken-core](https://github.com/octoenergy/kraken-core/commit/66130696bfe353ab3a09a316ce4c03747248025e#diff-d693b2faa093742e7045e9d6606e499d5ff59a8c9625968286d5abf230c28e35L1262) - which should not be the case <sup>[1](https://docs.pact.io/getting_started/versioning_in_the_pact_broker), [2](https://docs.pact.io/pact_broker/pacticipant_version_numbers)</sup>. 

- This pull request changes the name of the parameter `pact_version` to `consumer_version`. 
- The `pact_` prefix of all the other parameter names is dropped as well because Pact is the whole context of that function and there doesn't need to be a differentiation to other parameters.

**Extra**:

As this is the first time for me contributing to this package and I just installed the requirements today, Django 5 was installed instead of Django 4. Running the tests led to an error due to non-existing deprecation warnings that were ignored previously. I fixed the test and removed the ignore directives.  