### PR TITLE
Demonstrate issue with FiniteDateTimeRangeField

### DIFF
--- a/tests/fields/postgres/test_ranges.py
+++ b/tests/fields/postgres/test_ranges.py
@@ -270,6 +270,23 @@ class TestFiniteDateTimeRangeField:
         assert obj.finite_datetime_range.start.tzinfo == TZ_DEFAULT
         assert obj.finite_datetime_range.start.tzinfo != TZ_MELB
 
+    @pytest.mark.xfail(
+        raises=ValueError,
+        reason="DST issue",
+        strict=True,
+    )
+    def test_dst_issue(self):
+        dst_missing_hour = ranges.FiniteDatetimeRange(
+            start=datetime.datetime(2021, 10, 31, 0, tzinfo=datetime.timezone.utc),
+            end=datetime.datetime(2021, 10, 31, 1, tzinfo=datetime.timezone.utc),
+        )
+        models.FiniteDateTimeRangeModel.objects.create(
+            finite_datetime_range=dst_missing_hour,
+        )
+        # Unable to get the data because the datetime (stored as UTC) is converted to a DST timezone
+        # and then both start and end == datetime.datetime(2021, 10, 31, 1,)
+        models.FiniteDateTimeRangeModel.objects.get()
+
 
 class TestHalfFiniteDateTimeRangeField:
     def test_roundtrip(self):


### PR DESCRIPTION
This commit shows the existence of an edge case introduced by this change: 7558f7105dc4053bca190e927df0206923ea30a9

If we store the last hour of the DST period we won't be able to convert it to a proper `FiniteDatetimeRange`. Because we set clocks back by one hour then start == end.