### PR TITLE
Make tests pass in Django>=5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,10 +211,6 @@ filterwarnings = [
     "ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3:DeprecationWarning:(graphene|singledispatch)",
     # https://github.com/ktosiek/pytest-freezegun/issues/35
     "ignore:distutils Version classes are deprecated:DeprecationWarning:pytest_freezegun",
-    # These deprecation warnings were added in django 4.2 to warn of removal in django 5
-    "ignore:The USE_DEPRECATED_PYTZ setting:django.utils.deprecation.RemovedInDjango50Warning",
-    "ignore:The django.utils.timezone.utc alias is deprecated:django.utils.deprecation.RemovedInDjango50Warning",
-    "ignore:The is_dst argument to make_aware:django.utils.deprecation.RemovedInDjango50Warning",
 ]
 
 DJANGO_SETTINGS_MODULE = "tests.settings"

--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -1209,7 +1209,7 @@ class TestParseDatetime:
 class TestStrftime:
     @override_settings(TIME_ZONE="Europe/Berlin")
     def test_formats_datetime_in_local_timezone(self):
-        dt = datetime.datetime(2023, 10, 1, 22, 30, 0, tzinfo=timezone.utc)
+        dt = datetime.datetime(2023, 10, 1, 22, 30, 0, tzinfo=datetime.timezone.utc)
         fmt = "%Y-%m-%d %H:%M:%S %z"
 
         assert localtime.strftime(dt, fmt) == "2023-10-02 00:30:00 +0200"


### PR DESCRIPTION
Django 5.0 removed the alias `django.utils.timezone.utc` to `datetime.timezone.utc`.

Remove unnecessary deprecation warning filters for pytest.