### PR TITLE
Fix bug with `list_files`  method in `S3SubdirectoryFileStore`

### DIFF
--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -175,7 +175,6 @@ class TestS3SubdirectoryFileStore:
             Prefix="folder/a/b"
         )
 
-    @pytest.mark.xfail(reason="Expose bug when listing files with no bucket path")
     @mock.patch.object(storage.S3FileStore, "_get_boto_bucket")
     def test_list_files_no_path(self, get_boto_bucket):
         get_boto_bucket.return_value = mock.Mock(

--- a/xocto/storage/storage.py
+++ b/xocto/storage/storage.py
@@ -1013,10 +1013,12 @@ class S3SubdirectoryFileStore(S3FileStore):
         return objects, next_token
 
     def list_files(self, namespace: str = "") -> Iterable[str]:
+        path_trim = 0
         if self.path:
+            path_trim = len(self.path) + 1
             namespace = os.path.join(self.path, namespace)
         full_paths = super().list_files(namespace)
-        yield from (path[len(self.path) + 1 :] for path in full_paths)
+        yield from (path[path_trim:] for path in full_paths)
 
     def copy(self, *, s3_object: S3Object, destination: str) -> S3Object:
         if self.path:


### PR DESCRIPTION
🐛 Fix bug with `list_files`  method in `S3SubdirectoryFileStore`

Previously
---
If `S3SubdirectoryFileStore` was initialized with no path other than the s3 bucket
ie. `s3://bucket-name`
The `list_files` method would incorrectly trim the returned paths

e.g
expected: 
```
something/other/a.txt
```
returned: 
```
omething/other/a.txt
```


This change
---
Does not trim the returned paths if `S3SubdirectoryFileStore` is initialized with no path.