### PR TITLE
Add parameter to DateTime-based range fields

### DIFF
--- a/docs/xocto/model_fields.md
+++ b/docs/xocto/model_fields.md
@@ -92,7 +92,8 @@ Type: [xocto.ranges.FiniteDatetimeRange](xocto.ranges.FiniteDatetimeRange)
 A field that represents an inclusive-exclusive `[)` ranges of timezone-aware
 datetimes. Both the start and end of the range must not be `None`.
 
-The values returned from the database will always be converted to the local timezone
+The values returned from the database will be converted to `timezone` if
+provided. If not provided, the values will be converted to the local timezone
 as per the `TIME_ZONE` setting in `settings.py`.
 
 ```python
@@ -132,7 +133,8 @@ Type: [xocto.ranges.HalfFiniteDatetimeRange](xocto.ranges.HalfFiniteRange)
 A field that represents an inclusive-exclusive `[)` ranges of timezone-aware
 datetimes. The end of the range may be open-ended, represented by `None`.
 
-The values returned from the database will always be converted to the local timezone
+The values returned from the database will be converted to `timezone` if
+provided. If not provided, the values will be converted to the local timezone
 as per the `TIME_ZONE` setting in `settings.py`.
 
 ```python

--- a/tests/models/models.py
+++ b/tests/models/models.py
@@ -1,3 +1,5 @@
+import zoneinfo
+
 from django.db import models
 
 from xocto.fields.postgres import ranges as range_fields
@@ -11,10 +13,16 @@ class FiniteDateRangeModel(models.Model):
 class FiniteDateTimeRangeModel(models.Model):
     finite_datetime_range = range_fields.FiniteDateTimeRangeField()
     finite_datetime_range_nullable = range_fields.FiniteDateTimeRangeField(null=True)
+    finite_datetime_range_utc = range_fields.FiniteDateTimeRangeField(
+        timezone=zoneinfo.ZoneInfo("UTC"), null=True
+    )
 
 
 class HalfFiniteDateTimeRangeModel(models.Model):
     half_finite_datetime_range = range_fields.HalfFiniteDateTimeRangeField()
     half_finite_datetime_range_nullable = range_fields.HalfFiniteDateTimeRangeField(
         null=True
+    )
+    half_finite_datetime_range_utc = range_fields.HalfFiniteDateTimeRangeField(
+        timezone=zoneinfo.ZoneInfo("UTC"), null=True
     )

--- a/tests/models/models.py
+++ b/tests/models/models.py
@@ -18,11 +18,23 @@ class FiniteDateTimeRangeModel(models.Model):
     )
 
 
+class FiniteDateTimeRangeUTCModel(models.Model):
+    finite_datetime_range = range_fields.FiniteDateTimeRangeField(
+        timezone=zoneinfo.ZoneInfo("UTC"), null=True
+    )
+
+
 class HalfFiniteDateTimeRangeModel(models.Model):
     half_finite_datetime_range = range_fields.HalfFiniteDateTimeRangeField()
     half_finite_datetime_range_nullable = range_fields.HalfFiniteDateTimeRangeField(
         null=True
     )
     half_finite_datetime_range_utc = range_fields.HalfFiniteDateTimeRangeField(
+        timezone=zoneinfo.ZoneInfo("UTC"), null=True
+    )
+
+
+class HalfFiniteDateTimeRangeUTCModel(models.Model):
+    half_finite_datetime_range = range_fields.HalfFiniteDateTimeRangeField(
         timezone=zoneinfo.ZoneInfo("UTC"), null=True
     )


### PR DESCRIPTION
## Prior to this change

Since https://github.com/octoenergy/xocto/commit/7558f7105dc4053bca190e927df0206923ea30a9 values returned from DB are converted in local timezone.

## This change

This change adds an optional parameter allowing to choose whether or not to convert values into local timezone.

## Why it's needed

We cannot use those fields with the last hour of the DST period (demonstration here: #169). We need an option to not convert values to local timezone and keep them in UTC.