### PR TITLE
Bump version to v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 
+## v6.1.0 - 2024-08-30
+
+- Add optional `timezone` parameter to datetime-based range fields [#174] (https://github.com/octoenergy/xocto/pull/174)
+
 ## v6.0.0 - 2024-08-30
 
 - [Breaking] Use parameter object for passing options to `pact_service`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xocto"
-version = "6.0.0"
+version = "6.1.0"
 requires-python = ">=3.9"
 description = "Kraken Technologies Python service utilities"
 readme = "README.md"


### PR DESCRIPTION
# 6.1.0

* Add optional `timezone` parameter to datetime-based range fields: #174