### PR TITLE
Allow datetime.date for different localtime functions

### DIFF
--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -565,6 +565,10 @@ class TestStartOfMonth:
                 localtime.datetime(2017, 3, 31, 11, 29, 59),
                 localtime.datetime(2017, 3, 1, 0, 0, 0),
             ),
+            (
+                factories.date("2016-12-5"),
+                localtime.datetime(2016, 12, 1, 0, 0, 0),
+            ),
         ],
     )
     def test_start_of_month(self, dt, result):
@@ -582,6 +586,10 @@ class TestEndOfMonth:
             (
                 localtime.datetime(2017, 3, 31, 11, 29, 59),
                 localtime.datetime(2017, 4, 1, 0, 0, 0),
+            ),
+            (
+                factories.date("2016-12-5"),
+                localtime.datetime(2017, 1, 1, 0, 0, 0),
             ),
         ],
     )

--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -442,7 +442,9 @@ def is_last_day_of_month(_date: datetime_.date) -> bool:
     return False
 
 
-def start_of_month(dt: datetime_.datetime | None = None) -> datetime_.datetime:
+def start_of_month(
+    dt: datetime_.datetime | datetime_.date | None = None,
+) -> datetime_.datetime:
     """
     Return the start datetime of the month for dt passed - or of current month.
     """
@@ -451,7 +453,9 @@ def start_of_month(dt: datetime_.datetime | None = None) -> datetime_.datetime:
     return midnight(dt + relativedelta(day=1))
 
 
-def end_of_month(dt: datetime_.datetime | None = None) -> datetime_.datetime:
+def end_of_month(
+    dt: datetime_.datetime | datetime_.date | None = None,
+) -> datetime_.datetime:
     """
     Return the start datetime of the next month for dt passed - or of next month.
     """
@@ -460,22 +464,30 @@ def end_of_month(dt: datetime_.datetime | None = None) -> datetime_.datetime:
     return midnight(dt + relativedelta(day=1, months=1))
 
 
-def first_day_of_month(dt: datetime_.datetime | None = None) -> datetime_.date:
+def first_day_of_month(
+    dt: datetime_.datetime | datetime_.date | None = None,
+) -> datetime_.date:
     """
     Return the start date of the month for dt passed - or of current month.
     """
     if dt is None:
         dt = now()
-    return (dt + relativedelta(day=1)).date()
+    if isinstance(dt, datetime_.datetime):
+        return (dt + relativedelta(day=1)).date()
+    return dt + relativedelta(day=1)
 
 
-def last_day_of_month(dt: datetime_.datetime | None = None) -> datetime_.date:
+def last_day_of_month(
+    dt: datetime_.datetime | datetime_.date | None = None,
+) -> datetime_.date:
     """
     Return the last date of the month for dt passed - or of current month.
     """
     if dt is None:
         dt = now()
-    return (dt + relativedelta(day=31)).date()
+    if isinstance(dt, datetime_.datetime):
+        return (dt + relativedelta(day=31)).date()
+    return dt + relativedelta(day=31)
 
 
 def is_n_days_until_end_of_month(n_days: int) -> bool:


### PR DESCRIPTION
Some of the functions in the `localtime` module insist on `datetime.datetime` inputs when `datetime.date` also works. This PR aims to make these functions more flexible to avoid things like:

```
some_date = datetime.date(2024, 12, 6)
end_of_month = localtime.end_of_month(localtime.midnight(some_date))
```