### PR TITLE
Encapsulate date_range... fn in FiniteDatetimeRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `FiniteDatetimeRange.as_date_range` [#181](https://github.com/octoenergy/xocto/pull/181)
+- [Breaking] Remove `ranges.date_range_for_midnight_range` (replaced by FiniteDatetimeRange.as_date_range)[#181] (https://github.com/octoenergy/xocto/pull/181)
+
 ## v6.2.0 - 2024-12-11
 
 - Add `ranges.date_range_for_midnight_range` [#178] (https://github.com/octoenergy/xocto/pull/178)

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1028,6 +1028,53 @@ class TestFiniteDatetimeRange:
 
             assert "naive" in str(exc_info.value)
 
+    class TestAsDateRange:
+        def test_returns_date_range(self):
+            dt_range = ranges.FiniteDatetimeRange(
+                datetime.datetime(2020, 1, 1),
+                datetime.datetime(2020, 1, 10),
+            )
+
+            assert dt_range.as_date_range() == ranges.FiniteDateRange(
+                datetime.date(2020, 1, 1),
+                datetime.date(2020, 1, 9),
+            )
+
+        def test_errors_if_different_timezones(self):
+            dt_range = ranges.FiniteDatetimeRange(
+                datetime.datetime(2020, 1, 1, tzinfo=zoneinfo.ZoneInfo("Asia/Dubai")),
+                datetime.datetime(
+                    2020, 1, 10, tzinfo=zoneinfo.ZoneInfo("Australia/Sydney")
+                ),
+            )
+
+            with pytest.raises(ValueError) as exc_info:
+                dt_range.as_date_range()
+
+            assert "Start and end in different timezones" in str(exc_info.value)
+
+        def test_errors_if_start_not_midnight(self):
+            dt_range = ranges.FiniteDatetimeRange(
+                datetime.datetime(2020, 1, 1, hour=1),
+                datetime.datetime(2020, 1, 10),
+            )
+
+            with pytest.raises(ValueError) as exc_info:
+                dt_range.as_date_range()
+
+            assert "Start of range is not midnight-aligned" in str(exc_info.value)
+
+        def test_errors_if_end_not_midnight(self):
+            dt_range = ranges.FiniteDatetimeRange(
+                datetime.datetime(2020, 1, 1),
+                datetime.datetime(2020, 1, 10, hour=1),
+            )
+
+            with pytest.raises(ValueError) as exc_info:
+                dt_range.as_date_range()
+
+            assert "End of range is not midnight-aligned" in str(exc_info.value)
+
 
 class TestAsFiniteDatetimePeriods:
     def test_converts(self):
@@ -1185,54 +1232,6 @@ class TestIterateOverMonths:
         )
 
         assert result == row["expected"]
-
-
-class TestDateRangeForMidnightRange:
-    def test_returns_date_range(self):
-        dt_range = ranges.FiniteDatetimeRange(
-            datetime.datetime(2020, 1, 1),
-            datetime.datetime(2020, 1, 10),
-        )
-
-        assert ranges.date_range_for_midnight_range(dt_range) == ranges.FiniteDateRange(
-            datetime.date(2020, 1, 1),
-            datetime.date(2020, 1, 9),
-        )
-
-    def test_errors_if_different_timezones(self):
-        dt_range = ranges.FiniteDatetimeRange(
-            datetime.datetime(2020, 1, 1, tzinfo=zoneinfo.ZoneInfo("Asia/Dubai")),
-            datetime.datetime(
-                2020, 1, 10, tzinfo=zoneinfo.ZoneInfo("Australia/Sydney")
-            ),
-        )
-
-        with pytest.raises(ValueError) as exc_info:
-            ranges.date_range_for_midnight_range(dt_range)
-
-        assert "Start and end in different timezones" in str(exc_info.value)
-
-    def test_errors_if_start_not_midnight(self):
-        dt_range = ranges.FiniteDatetimeRange(
-            datetime.datetime(2020, 1, 1, hour=1),
-            datetime.datetime(2020, 1, 10),
-        )
-
-        with pytest.raises(ValueError) as exc_info:
-            ranges.date_range_for_midnight_range(dt_range)
-
-        assert "Start of range is not midnight-aligned" in str(exc_info.value)
-
-    def test_errors_if_end_not_midnight(self):
-        dt_range = ranges.FiniteDatetimeRange(
-            datetime.datetime(2020, 1, 1),
-            datetime.datetime(2020, 1, 10, hour=1),
-        )
-
-        with pytest.raises(ValueError) as exc_info:
-            ranges.date_range_for_midnight_range(dt_range)
-
-        assert "End of range is not midnight-aligned" in str(exc_info.value)
 
 
 def _rangeset_from_string(rangeset_str: str) -> ranges.RangeSet[int]:


### PR DESCRIPTION
Follow-up to [^1].

This moves/renames `ranges.date_range_for_midnight_range` so it's
a method: `FiniteDatetimeRange.as_date_range` - more concise.

Before:

    ranges.date_range_for_midnight_range(
        dt_range.localize(my_timezone)  # common pre-step
    )

After:

    dt_range.localize(my_timezone).as_date_range()

The behaviour is unchanged: only midnight ranges, which fully span
a date range, are supported in the conversion.

[^1]: :pr: [Add "localize" and "date_range_for_midnight_range" fns](https://github.com/octoenergy/xocto/pull/178)