### PR TITLE
Optimise `ranges.any_overlapping`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.benchmarks/
+
 # Byte-compiled / optimized files
 *.py[cod]
 __pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Improve the performance of the `ranges.any_overlapping` function
+  (with some benchmark showing a >100x speed up) [#184](https://github.com/octoenergy/xocto/pull/184).
+
 ## V7.0.0 - 2024-12-19
 
 - Add `FiniteDatetimeRange.as_date_range` [#181](https://github.com/octoenergy/xocto/pull/181)

--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ test:
 	py.test  --benchmark-skip
 
 benchmark:
-	py.test  --benchmark-only
+	py.test  --benchmark-only --benchmark-autosave --benchmark-compare
 
 mypy:
 	mypy

--- a/makefile
+++ b/makefile
@@ -14,7 +14,10 @@ lint_check:
 	ruff check .
 
 test:
-	py.test
+	py.test  --benchmark-skip
+
+benchmark:
+	py.test  --benchmark-only
 
 mypy:
 	mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
   "pre-commit>=3.7.1",
   "psycopg2>=2.8.4",
   "pyarrow-stubs==10.0.1.6",
+  "pytest-benchmark==5.0.1",
   "pytest-django==4.8.0",
   "pytest-mock==3.12.0",
   "pytest==8.0.2",

--- a/tests/benchmarks/test_ranges.py
+++ b/tests/benchmarks/test_ranges.py
@@ -1,0 +1,13 @@
+import random
+from decimal import Decimal as D
+
+from xocto import ranges
+
+
+def test_any_overlapping(benchmark):
+    ranges_ = [ranges.Range(D(i), D(i + 1)) for i in range(1000)]
+    random.seed(42)
+    random.shuffle(ranges_)
+
+    any_overlapping = benchmark(ranges.any_overlapping, ranges_)
+    assert any_overlapping is False

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -597,6 +597,13 @@ class TestAnyOverlapping:
                 ranges.Range(1, 3),
             ],
             [
+                ranges.Range(0, 2),
+                ranges.Range(
+                    4, 5
+                ),  # Added this to ensure the overlapping ranges are not adjacent.
+                ranges.Range(1, 3),
+            ],
+            [
                 ranges.Range(
                     0, 2, boundaries=ranges.RangeBoundaries.INCLUSIVE_INCLUSIVE
                 ),

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -1054,14 +1054,16 @@ def get_finite_datetime_ranges_from_timestamps(
 
 def any_overlapping(ranges: Iterable[Range[T]]) -> bool:
     """Return true if any of the passed Ranges are overlapping."""
-    ranges = list(ranges)
+    # We're deliberately not using RangeSet here for better performance.
+    # See https://github.com/octoenergy/xocto/pull/184.
     if not ranges:
         return False
-    range_set = RangeSet[T]([ranges[0]])
+    ranges = sorted(ranges)
+    prev_range: Range[T] = ranges[0]
     for range in ranges[1:]:
-        if range_set.intersection(range):
+        if prev_range.intersection(range):
             return True
-        range_set.add(range)
+        prev_range = range
     return False
 
 


### PR DESCRIPTION
This PR optimises the `ranges.any_overlapping` function. It uses `pytest-benchmark` to measure the improvement. The resulting function is >100x faster for this benchmark..!

Kraken: This function is often used to determine whether there are overlaps in meter readings etc and has a significant impact on costing performance.  

```
-------------------------------------------------------------------------------------------- benchmark: 2 tests --------------------------------------------------------------------------------------------
Name (time in ms)                            Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_any_overlapping (NOW)                1.4645 (1.0)        1.5542 (1.0)        1.4730 (1.0)      0.0099 (1.0)        1.4699 (1.0)      0.0032 (1.0)         70;93  678.8814 (1.0)         641           1
test_any_overlapping (0004_ce35b5e)     191.0346 (130.44)   207.6654 (133.61)   194.7505 (132.21)   6.6148 (666.40)   191.3241 (130.16)   4.8863 (>1000.0)       1;1    5.1348 (0.01)          6           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```