### PR TITLE
Optimise FiniteDatetimeRange __lt__, intersection and union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Improve the performance of `FiniteDatetimeRange.intersection`,
+  `FiniteDatetimeRange.union` and `FiniteDatetimeRange.__lt__` [#187](https://github.com/octoenergy/xocto/pull/187).
+
 ## V7.1.0 - 2025-01-13
 
 - Add `ranges.any_gaps` function [#185](https://github.com/octoenergy/xocto/pull/185).

--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ test:
 	py.test  --benchmark-skip
 
 benchmark:
-	py.test  --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-group-by=func
+	py.test  --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-group-by=func --benchmark-columns mean,rounds,iterations
 
 mypy:
 	mypy

--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ test:
 	py.test  --benchmark-skip
 
 benchmark:
-	py.test  --benchmark-only --benchmark-autosave --benchmark-compare
+	py.test  --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-group-by=func
 
 mypy:
 	mypy

--- a/tests/benchmarks/test_ranges.py
+++ b/tests/benchmarks/test_ranges.py
@@ -1,8 +1,6 @@
 import random
 from decimal import Decimal as D
 
-import pytest
-
 from xocto import ranges
 
 
@@ -13,14 +11,12 @@ def _shuffled(ranges_, *, seed=42):
     return ranges_
 
 
-@pytest.mark.benchmark(group="ranges.any_overlapping")
 def test_any_overlapping(benchmark):
     ranges_ = _shuffled([ranges.Range(D(i), D(i + 1)) for i in range(1000)])
     any_overlapping = benchmark(ranges.any_overlapping, ranges_)
     assert any_overlapping is False
 
 
-@pytest.mark.benchmark(group="ranges.any_gaps")
 def test_any_gaps(benchmark):
     ranges_ = _shuffled([ranges.Range(D(i), D(i + 1)) for i in range(1000)])
     any_overlapping = benchmark(ranges.any_gaps, ranges_)

--- a/tests/benchmarks/test_ranges.py
+++ b/tests/benchmarks/test_ranges.py
@@ -1,3 +1,4 @@
+import datetime
 import random
 from decimal import Decimal as D
 
@@ -21,3 +22,67 @@ def test_any_gaps(benchmark):
     ranges_ = _shuffled([ranges.Range(D(i), D(i + 1)) for i in range(1000)])
     any_overlapping = benchmark(ranges.any_gaps, ranges_)
     assert any_overlapping is False
+
+
+class TestFiniteDatetimeRange:
+    def test_intersection_is_none(self, benchmark):
+        r1 = ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 1),
+            datetime.datetime(2020, 1, 2),
+        )
+        r2 = ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 3),
+            datetime.datetime(2020, 1, 4),
+        )
+
+        result = benchmark(lambda: r2 & r1)
+
+        assert result is None
+
+    def test_intersection_is_not_none(self, benchmark):
+        r1 = ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 1),
+            datetime.datetime(2020, 1, 3),
+        )
+        r2 = ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 2),
+            datetime.datetime(2020, 1, 4),
+        )
+
+        result = benchmark(lambda: r2 & r1)
+
+        assert result == ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 2),
+            datetime.datetime(2020, 1, 3),
+        )
+
+    def test_union_is_none(self, benchmark):
+        r1 = ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 1),
+            datetime.datetime(2020, 1, 2),
+        )
+        r2 = ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 3),
+            datetime.datetime(2020, 1, 4),
+        )
+
+        result = benchmark(lambda: r2 | r1)
+
+        assert result is None
+
+    def test_union_is_not_none(self, benchmark):
+        r1 = ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 1),
+            datetime.datetime(2020, 1, 3),
+        )
+        r2 = ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 2),
+            datetime.datetime(2020, 1, 4),
+        )
+
+        result = benchmark(lambda: r2 | r1)
+
+        assert result == ranges.FiniteDatetimeRange(
+            datetime.datetime(2020, 1, 1),
+            datetime.datetime(2020, 1, 4),
+        )

--- a/tests/benchmarks/test_ranges.py
+++ b/tests/benchmarks/test_ranges.py
@@ -86,3 +86,17 @@ class TestFiniteDatetimeRange:
             datetime.datetime(2020, 1, 1),
             datetime.datetime(2020, 1, 4),
         )
+
+    def test_sorting(self, benchmark):
+        sorted_ranges_ = []
+        dt = datetime.datetime(2020, 1, 1)
+        for _ in range(100_000):
+            sorted_ranges_.append(
+                ranges.FiniteDatetimeRange(dt, dt + datetime.timedelta(hours=1))
+            )
+            dt += datetime.timedelta(hours=1)
+
+        ranges_ = _shuffled(sorted_ranges_)
+
+        result = benchmark(lambda: sorted(ranges_))
+        assert result == sorted_ranges_

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1019,6 +1019,60 @@ class TestFiniteDateRange:
 
 
 class TestFiniteDatetimeRange:
+    @pytest.mark.parametrize(
+        "r1, r2, expected",
+        [
+            [
+                ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 1),
+                    end=datetime.datetime(2000, 1, 3),
+                ),
+                ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 2),
+                    end=datetime.datetime(2000, 1, 4),
+                ),
+                True,
+            ],
+            [
+                ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 2),
+                    end=datetime.datetime(2000, 1, 4),
+                ),
+                ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 1),
+                    end=datetime.datetime(2000, 1, 3),
+                ),
+                False,
+            ],
+            [
+                ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 1),
+                    end=datetime.datetime(2000, 1, 3),
+                ),
+                ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 1),
+                    end=datetime.datetime(2000, 1, 5),
+                ),
+                # False, since only `start` is considered.
+                False,
+            ],
+            [
+                ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 1),
+                    end=datetime.datetime(2000, 1, 3),
+                ),
+                ranges.Range(
+                    start=None,
+                    end=datetime.datetime(3000, 1, 1),
+                    boundaries=ranges.RangeBoundaries.EXCLUSIVE_EXCLUSIVE,
+                ),
+                False,
+            ],
+        ],
+    )
+    def test__lt__(self, r1, r2, expected):
+        assert (r1 < r2) is expected
+
     class TestUnion:
         def test_union_of_touching_ranges(self):
             range = ranges.FiniteDatetimeRange(

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1030,11 +1030,13 @@ class TestFiniteDatetimeRange:
                 end=datetime.datetime(2000, 1, 3),
             )
 
-            union = range | other
-
-            assert union == ranges.FiniteDatetimeRange(
-                start=datetime.datetime(2000, 1, 1),
-                end=datetime.datetime(2000, 1, 3),
+            assert (
+                range | other
+                == other | range
+                == ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 1),
+                    end=datetime.datetime(2000, 1, 3),
+                )
             )
 
         def test_union_of_disjoint_ranges(self):
@@ -1047,7 +1049,7 @@ class TestFiniteDatetimeRange:
                 end=datetime.datetime(2020, 1, 2),
             )
 
-            assert range | other is None
+            assert (range | other is None) and (other | range is None)
 
         def test_union_of_overlapping_ranges(self):
             range = ranges.FiniteDatetimeRange(
@@ -1059,11 +1061,57 @@ class TestFiniteDatetimeRange:
                 end=datetime.datetime(2000, 1, 4),
             )
 
-            union = range | other
+            assert (
+                range | other
+                == other | range
+                == ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 1),
+                    end=datetime.datetime(2000, 1, 4),
+                )
+            )
 
-            assert union == ranges.FiniteDatetimeRange(
+    class TestIntersection:
+        def test_intersection_of_touching_ranges(self):
+            range = ranges.FiniteDatetimeRange(
                 start=datetime.datetime(2000, 1, 1),
+                end=datetime.datetime(2000, 1, 2),
+            )
+            other = ranges.FiniteDatetimeRange(
+                start=datetime.datetime(2000, 1, 2),
+                end=datetime.datetime(2000, 1, 3),
+            )
+
+            assert (range & other is None) and (other & range is None)
+
+        def test_intersection_of_disjoint_ranges(self):
+            range = ranges.FiniteDateRange(
+                start=datetime.datetime(2000, 1, 1),
+                end=datetime.datetime(2000, 1, 2),
+            )
+            other = ranges.FiniteDatetimeRange(
+                start=datetime.datetime(2020, 1, 1),
+                end=datetime.datetime(2020, 1, 2),
+            )
+
+            assert (range & other is None) and (other & range is None)
+
+        def test_intersection_of_overlapping_ranges(self):
+            range = ranges.FiniteDatetimeRange(
+                start=datetime.datetime(2000, 1, 1),
+                end=datetime.datetime(2000, 1, 3),
+            )
+            other = ranges.FiniteDatetimeRange(
+                start=datetime.datetime(2000, 1, 2),
                 end=datetime.datetime(2000, 1, 4),
+            )
+
+            assert (
+                range & other
+                == other & range
+                == ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2000, 1, 2),
+                    end=datetime.datetime(2000, 1, 3),
+                )
             )
 
     class TestLocalize:

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -843,6 +843,16 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
         """
         Intersections with finite ranges will always be finite.
         """
+        if isinstance(other, FiniteDatetimeRange):
+            # We're deliberately overriding the base class here for better performance.
+            # We can simplify the implementation since we know we're dealing with finite
+            # ranges with INCLUSIVE_EXCLUSIVE bounds.
+            left, right = (self, other) if self.start < other.start else (other, self)
+            if left.end <= right.start:
+                return None
+            else:
+                return FiniteDatetimeRange(right.start, min(left.end, right.end))
+
         base_intersection = super().intersection(other)
         if base_intersection is None:
             return None
@@ -854,6 +864,16 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
         """
         Unions between two FiniteDatetimeRanges should produce a FiniteDatetimeRange.
         """
+        if isinstance(other, FiniteDatetimeRange):
+            # We're deliberately overriding the base class here for better performance.
+            # We can simplify the implementation since we know we're dealing with finite
+            # ranges with INCLUSIVE_EXCLUSIVE bounds.
+            left, right = (self, other) if self.start < other.start else (other, self)
+            if left.end < right.start:
+                return None
+            else:
+                return FiniteDatetimeRange(left.start, max(left.end, right.end))
+
         try:
             base_union = super().union(other)
         except ValueError:

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -837,6 +837,15 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
         """
         super().__init__(start, end, boundaries=RangeBoundaries.INCLUSIVE_EXCLUSIVE)
 
+    def __lt__(self, other: Range[datetime.datetime]) -> bool:
+        # We're deliberately overriding the base class here for better performance.
+        if other.start is None:
+            # We don't need to check anything more if the other range
+            # is open-ended
+            return False
+        else:
+            return self.start < other.start
+
     def intersection(
         self, other: Range[datetime.datetime]
     ) -> Optional["FiniteDatetimeRange"]:


### PR DESCRIPTION
This PR optimises the performance of some key `FiniteDatetimeRange` methods: `__lt__`, `intersection` and `union`. This optimisation is achieved by overriding the generic base class implementation with a custom implementation of these methods. These custom implementations exploit the fact that `FiniteDatetimeRange` are always finite and having `INCLUSIVE_EXCLUSIVE` bounds.

This optimisation adds a little complexity to the code (more lines of code is more to maintain). So why should we do this? In Kraken `FiniteDatetimeRange` are used heavily in cost calculations, and these operations can take up a significant amount of the computational time. This optimisation should have give a small but noticeable performance benefit. 

```py
------------------ benchmark 'test_intersection_is_none': 2 tests -----------------
Name (time in ns)                                Mean            Rounds  Iterations
-----------------------------------------------------------------------------------
test_intersection_is_none (NOW)              261.4016 (1.0)      192013          19
test_intersection_is_none (0058_24b4d5c)     960.9678 (3.68)     183218           1
-----------------------------------------------------------------------------------

----------------- benchmark 'test_intersection_is_not_none': 2 tests ----------------
Name (time in us)                                  Mean            Rounds  Iterations
-------------------------------------------------------------------------------------
test_intersection_is_not_none (NOW)              2.8469 (1.0)      190477           1
test_intersection_is_not_none (0058_24b4d5c)     7.1524 (2.51)      79739           1
-------------------------------------------------------------------------------------

----------------- benchmark 'test_sorting': 2 tests ------------------
Name (time in ms)                   Mean            Rounds  Iterations
----------------------------------------------------------------------
test_sorting (NOW)              140.7984 (1.0)           7           1
test_sorting (0058_24b4d5c)     212.3164 (1.51)          5           1
----------------------------------------------------------------------

----------------- benchmark 'test_union_is_none': 2 tests ------------------
Name (time in ns)                         Mean            Rounds  Iterations
----------------------------------------------------------------------------
test_union_is_none (NOW)              264.6992 (1.0)      176461          20
test_union_is_none (0058_24b4d5c)     685.8727 (2.59)      68767          20
----------------------------------------------------------------------------

---------------- benchmark 'test_union_is_not_none': 2 tests -----------------
Name (time in us)                           Mean            Rounds  Iterations
------------------------------------------------------------------------------
test_union_is_not_none (NOW)              2.9004 (1.0)      162154           1
test_union_is_not_none (0058_24b4d5c)     6.4389 (2.22)      53451           1
------------------------------------------------------------------------------
```