### PR TITLE
Allow union of FiniteDatetimeRange with HalfFiniteDatetimeRange/DatetimeRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Allow the `union` operation between `FiniteDatetimeRange` and `HalfFiniteDatetimeRange` 
+  (and other `DatetimeRange`s) [#189](https://github.com/octoenergy/xocto/pull/189/).
+
 ## V7.1.1 - 2025-01-22
 
 - Improve the performance of `FiniteDatetimeRange.intersection`,

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1124,7 +1124,6 @@ class TestFiniteDatetimeRange:
                 )
             )
 
-        @pytest.mark.xfail
         @pytest.mark.parametrize(
             "range_, other, expected_union",
             [
@@ -1162,7 +1161,6 @@ class TestFiniteDatetimeRange:
         def test_union_with_half_finite_range(self, range_, other, expected_union):
             assert range_ | other == other | range_ == expected_union
 
-        @pytest.mark.xfail
         def test_union_with_continuum(self):
             range = ranges.FiniteDatetimeRange(
                 datetime.datetime(2020, 1, 1),

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1084,6 +1084,7 @@ class TestFiniteDatetimeRange:
                 end=datetime.datetime(2000, 1, 3),
             )
 
+            assert isinstance(range | other, ranges.FiniteDatetimeRange)
             assert (
                 range | other
                 == other | range
@@ -1115,6 +1116,7 @@ class TestFiniteDatetimeRange:
                 end=datetime.datetime(2000, 1, 4),
             )
 
+            assert isinstance(range | other, ranges.FiniteDatetimeRange)
             assert (
                 range | other
                 == other | range
@@ -1159,6 +1161,7 @@ class TestFiniteDatetimeRange:
             ],
         )
         def test_union_with_half_finite_range(self, range_, other, expected_union):
+            assert ranges._is_half_finite_datetime_range(range_ | other)
             assert range_ | other == other | range_ == expected_union
 
         def test_union_with_continuum(self):
@@ -1168,6 +1171,7 @@ class TestFiniteDatetimeRange:
             )
             other = ranges.DatetimeRange.continuum()
 
+            assert ranges._is_datetime_range(range | other)
             assert range | other == other | range == ranges.DatetimeRange.continuum()
 
     class TestIntersection:

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1124,6 +1124,44 @@ class TestFiniteDatetimeRange:
                 )
             )
 
+        @pytest.mark.xfail
+        @pytest.mark.parametrize(
+            "range_, other, expected_union",
+            [
+                [
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2020, 1, 1),
+                        datetime.datetime(2023, 1, 1),
+                    ),
+                    ranges.HalfFiniteDatetimeRange(
+                        datetime.datetime(2021, 1, 1),
+                        None,
+                    ),
+                    ranges.HalfFiniteDatetimeRange(
+                        start=datetime.datetime(2020, 1, 1),
+                        end=None,
+                    ),
+                ],
+                [
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2020, 1, 1),
+                        datetime.datetime(2023, 1, 1),
+                    ),
+                    ranges.HalfFiniteDatetimeRange(
+                        datetime.datetime(2021, 1, 1),
+                        datetime.datetime(2022, 1, 1),
+                    ),
+                    # The resulting range is finite, but it's still an instance of `HalfFiniteDatetimeRange`.
+                    ranges.HalfFiniteDatetimeRange(
+                        start=datetime.datetime(2020, 1, 1),
+                        end=datetime.datetime(2023, 1, 1),
+                    ),
+                ],
+            ],
+        )
+        def test_union_with_half_finite_range(self, range_, other, expected_union):
+            assert range_ | other == other | range_ == expected_union
+
     class TestIntersection:
         def test_intersection_of_touching_ranges(self):
             range = ranges.FiniteDatetimeRange(
@@ -1165,6 +1203,25 @@ class TestFiniteDatetimeRange:
                 == ranges.FiniteDatetimeRange(
                     start=datetime.datetime(2000, 1, 2),
                     end=datetime.datetime(2000, 1, 3),
+                )
+            )
+
+        def test_intersection_with_half_finite_range(self):
+            range = ranges.FiniteDatetimeRange(
+                datetime.datetime(2020, 1, 1),
+                datetime.datetime(2022, 1, 1),
+            )
+            other = ranges.HalfFiniteDatetimeRange(
+                datetime.datetime(2021, 1, 1),
+                None,
+            )
+
+            assert (
+                range & other
+                == other & range
+                == ranges.FiniteDatetimeRange(
+                    start=datetime.datetime(2021, 1, 1),
+                    end=datetime.datetime(2022, 1, 1),
                 )
             )
 

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1162,6 +1162,16 @@ class TestFiniteDatetimeRange:
         def test_union_with_half_finite_range(self, range_, other, expected_union):
             assert range_ | other == other | range_ == expected_union
 
+        @pytest.mark.xfail
+        def test_union_with_continuum(self):
+            range = ranges.FiniteDatetimeRange(
+                datetime.datetime(2020, 1, 1),
+                datetime.datetime(2022, 1, 1),
+            )
+            other = ranges.DatetimeRange.continuum()
+
+            assert range | other == other | range == ranges.DatetimeRange.continuum()
+
     class TestIntersection:
         def test_intersection_of_touching_ranges(self):
             range = ranges.FiniteDatetimeRange(

--- a/xocto/fields/postgres/ranges.py
+++ b/xocto/fields/postgres/ranges.py
@@ -181,7 +181,7 @@ class HalfFiniteDateTimeRangeField(_LocaliserMixin, pg_fields.DateTimeRangeField
     ) -> Optional[Union[pg_ranges.DateTimeTZRange, datetime.datetime]]:
         if value is None:
             return None
-        if self._is_half_finite_datetime_range(value):
+        if ranges._is_half_finite_datetime_range(value):
             return pg_ranges.DateTimeTZRange(
                 lower=value.start, upper=value.end, bounds="[)"
             )
@@ -233,14 +233,3 @@ class HalfFiniteDateTimeRangeField(_LocaliserMixin, pg_fields.DateTimeRangeField
                 "end": base_field.value_to_string(end),
             }
         )
-
-    def _is_half_finite_datetime_range(self, value: Any) -> bool:
-        # HalfFiniteDatetimeRange is a subscripted generic and may not be checked with
-        # isinstance directly. So, we check for it's parent class and attribute values.
-        if not isinstance(value, ranges.HalfFiniteRange):
-            return False
-        if not isinstance(value.start, datetime.datetime):
-            return False
-        if value.end is not None and not isinstance(value.end, datetime.datetime):
-            return False
-        return True

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -916,6 +916,23 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
     ) -> Optional["FiniteDatetimeRange"]:
         return self.intersection(other)
 
+    @overload
+    def __or__(self, other: FiniteDatetimeRange) -> Optional[FiniteDatetimeRange]: ...
+
+    @overload
+    def __or__(
+        self, other: HalfFiniteDatetimeRange
+    ) -> Optional[HalfFiniteDatetimeRange]: ...
+
+    @overload
+    def __or__(self, other: DatetimeRange) -> Optional[DatetimeRange]: ...
+
+    def __or__(
+        self,
+        other: DatetimeRange,
+    ) -> Optional[DatetimeRange]:
+        return self.union(other)
+
     @property
     def days(self) -> int:
         """


### PR DESCRIPTION
I noticed that it is not possible to take the union between a `FiniteDatetimeRange` and a `HalfFiniteDatetimeRange` (or a general `DatetimeRange`). The pre-existing implementation tries to force the result of `FiniteDatetimeRange.union` to also be finite, at which point the implementation errors since the union of a `FiniteDatetimeRange` and a `HalfFiniteDatetimeRange` will not in general be finite. 

This seems wrong - it should be possible to take the union of a `FiniteDatetimeRange` and a `HalfFiniteDatetimeRange`.

Maybe there has been some confusion with intersection here. The intersection of an `FiniteDatetimeRange` with a `HalfFiniteDatetimeRange` will always be finite, but the union will not be.

We could (likely should) make equivalent changes to `FiniteDateRange`, however I'd leave that for a separate PR.