### PR TITLE
Demo issue with datetime ranges

### DIFF
--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -20,6 +20,7 @@ from typing import (
 )
 
 from dateutil import relativedelta
+from django.utils import timezone
 
 from xocto.types import generic
 
@@ -871,6 +872,10 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
         self, other: Range[datetime.datetime]
     ) -> Optional["FiniteDatetimeRange"]:
         return self.intersection(other)
+
+    @property
+    def is_naive(self) -> bool:
+        return timezone.is_naive(self.start)
 
     @property
     def days(self) -> int:


### PR DESCRIPTION
This PR demonstrates an issue when mixing tzinfo in datetime ranges. See the test case.

The PR is branched from v7.1.0, demonstrating that this issue existed before v7.1.1. 

I've extracted an issue for this here https://github.com/octoenergy/xocto/issues/192.