### PR TITLE
Disallow datetime ranges with mixed tzinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- [Breaking] Prevent intersection/union of `FiniteDatetimeRange` with datetime 
+  range of inconsistent tzinfo [#194](https://github.com/octoenergy/xocto/pull/194).
+- [Breaking] Prevent construction of `FiniteDatetimeRange` with mixed 
+  tzinfo [#194](https://github.com/octoenergy/xocto/pull/194).
+- Add `ranges.get_tzinfo` function to get the tzinfo of a datetime range [#194](https://github.com/octoenergy/xocto/pull/194).
+
 ## V7.1.1 - 2025-01-22
 
 - Improve the performance of `FiniteDatetimeRange.intersection`,

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1019,6 +1019,15 @@ class TestFiniteDateRange:
 
 
 class TestFiniteDatetimeRange:
+    def test_cannot_construct_with_inconsistent_tzinfo(self):
+        with pytest.raises(ranges.InconsistentTzInfo):
+            tz_london = zoneinfo.ZoneInfo("Europe/London")
+            tz_berlin = zoneinfo.ZoneInfo("Europe/Berlin")
+            ranges.FiniteDatetimeRange(
+                datetime.datetime(2020, 1, 1, tzinfo=tz_london),
+                datetime.datetime(2021, 1, 1, tzinfo=tz_berlin),
+            )
+
     @pytest.mark.parametrize(
         "r1, r2, expected",
         [
@@ -1242,19 +1251,6 @@ class TestFiniteDatetimeRange:
                 datetime.date(2020, 1, 1),
                 datetime.date(2020, 1, 9),
             )
-
-        def test_errors_if_different_timezones(self):
-            dt_range = ranges.FiniteDatetimeRange(
-                datetime.datetime(2020, 1, 1, tzinfo=zoneinfo.ZoneInfo("Asia/Dubai")),
-                datetime.datetime(
-                    2020, 1, 10, tzinfo=zoneinfo.ZoneInfo("Australia/Sydney")
-                ),
-            )
-
-            with pytest.raises(ValueError) as exc_info:
-                dt_range.as_date_range()
-
-            assert "Start and end in different timezones" in str(exc_info.value)
 
         def test_errors_if_start_not_midnight(self):
             dt_range = ranges.FiniteDatetimeRange(

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -867,11 +867,20 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
             # We're deliberately overriding the base class here for better performance.
             # We can simplify the implementation since we know we're dealing with finite
             # ranges with INCLUSIVE_EXCLUSIVE bounds.
+            if self.tzinfo != other.tzinfo:
+                raise InconsistentTzInfo(
+                    "inconsistent tzinfo for datetime range intersection"
+                )
             left, right = (self, other) if self.start < other.start else (other, self)
             if left.end <= right.start:
                 return None
             else:
                 return FiniteDatetimeRange(right.start, min(left.end, right.end))
+
+        if self.tzinfo != get_tzinfo(other):
+            raise InconsistentTzInfo(
+                "inconsistent tzinfo for datetime range intersection"
+            )
 
         base_intersection = super().intersection(other)
         if base_intersection is None:
@@ -888,11 +897,16 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
             # We're deliberately overriding the base class here for better performance.
             # We can simplify the implementation since we know we're dealing with finite
             # ranges with INCLUSIVE_EXCLUSIVE bounds.
+            if self.tzinfo != other.tzinfo:
+                raise InconsistentTzInfo("inconsistent tzinfo for datetime range union")
             left, right = (self, other) if self.start < other.start else (other, self)
             if left.end < right.start:
                 return None
             else:
                 return FiniteDatetimeRange(left.start, max(left.end, right.end))
+
+        if self.tzinfo != get_tzinfo(other):
+            raise InconsistentTzInfo("inconsistent tzinfo for datetime range union")
 
         try:
             base_union = super().union(other)

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -832,13 +832,21 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
     of time.
     """
 
-    __slots__ = ()
+    tzinfo: Optional[datetime.tzinfo]
+    is_tz_aware: bool
+
+    __slots__ = ("tzinfo", "is_tz_aware")
 
     def __init__(self, start: datetime.datetime, end: datetime.datetime):
         """
         Force the boundaries of the range to be [).
         """
         super().__init__(start, end, boundaries=RangeBoundaries.INCLUSIVE_EXCLUSIVE)
+
+        # Calling `get_tzinfo` will check that the tzinfo is consistently defined.
+        tzinfo = get_tzinfo(self)
+        object.__setattr__(self, "tzinfo", tzinfo)
+        object.__setattr__(self, "is_tz_aware", tzinfo is not None)
 
     def __lt__(self, other: Range[datetime.datetime]) -> bool:
         # We're deliberately overriding the base class here for better performance.

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -26,6 +26,9 @@ from xocto.types import generic
 from . import localtime
 
 
+class InconsistentTzInfo(Exception): ...
+
+
 class RangeBoundaries(enum.Enum):
     EXCLUSIVE_EXCLUSIVE = "()"
     EXCLUSIVE_INCLUSIVE = "(]"
@@ -1151,3 +1154,17 @@ def iterate_over_months(
 
         yield FiniteDatetimeRange(start_at, this_end)
         start_at = next_start
+
+
+def get_tzinfo(dt_range: DatetimeRange) -> Optional[datetime.tzinfo]:
+    if dt_range.start is None:
+        if dt_range.end is None:
+            return None
+        return dt_range.end.tzinfo
+
+    if dt_range.end is None:
+        return dt_range.start.tzinfo
+
+    if dt_range.start.tzinfo != dt_range.end.tzinfo:
+        raise InconsistentTzInfo("inconsistent tzinfo for datetime range boundaries")
+    return dt_range.start.tzinfo

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -936,8 +936,12 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
             ValueError:
                 If one or both boundaries are naive (no timezone).
         """
-        if not self.start.tzinfo or not self.end.tzinfo:
+        if not self.is_tz_aware:
             raise ValueError("Cannot localize range with naive boundaries")
+
+        if tz == self.tzinfo:
+            # Ranges are immutable so we can just return self.
+            return self
 
         return FiniteDatetimeRange(
             self.start.astimezone(tz),


### PR DESCRIPTION
Context: https://github.com/octoenergy/xocto/issues/192

---

Update: I've tried this in Kraken but the number of errors was rather daunting. I think it's unlikely we find time to prioritise this change right now, so I'm proposing https://github.com/octoenergy/xocto/pull/195 as an alternative/first-step to unblock things.