### PR TITLE
Update `FiniteDatetimeRange.days` to require passing a TZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `localtime.get_local_tzinfo` [#195](https://github.com/octoenergy/xocto/pull/195).
 - [Breaking] Update `FiniteDatetimeRange.days` to require passing a timezone
   [#195](https://github.com/octoenergy/xocto/pull/195).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- [Breaking] Update `FiniteDatetimeRange.days` to require passing a timezone
+  [#195](https://github.com/octoenergy/xocto/pull/195).
+
 ## V7.1.1 - 2025-01-22
 
 - Improve the performance of `FiniteDatetimeRange.intersection`,

--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -28,6 +28,13 @@ ONE_HOUR = datetime_.timedelta(hours=1)
 MIDNIGHT_TIME = datetime_.time(0, 0)
 
 
+def get_local_tzinfo() -> datetime_.tzinfo:
+    """
+    Return the local tzinfo.
+    """
+    return timezone.get_current_timezone()
+
+
 def as_localtime(
     dt: datetime_.datetime, tz: datetime_.tzinfo | None = None
 ) -> datetime_.datetime:
@@ -383,8 +390,7 @@ def is_local_time(dt: datetime_.datetime) -> bool:
     """
     Test whether a given (timezone-aware) datetime is in local time or not.
     """
-    current_timezone = timezone.get_current_timezone()
-    return dt.tzinfo == current_timezone
+    return dt.tzinfo == get_local_tzinfo()
 
 
 def within_date_range(

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -860,7 +860,7 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
             if left.end <= right.start:
                 return None
             else:
-                return FiniteDatetimeRange(right.start, min(left.end, right.end))
+                return FiniteDatetimeRange(right.start, min(right.end, left.end))
 
         base_intersection = super().intersection(other)
         if base_intersection is None:

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -901,12 +901,12 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
     ) -> Optional["FiniteDatetimeRange"]:
         return self.intersection(other)
 
-    @property
-    def days(self) -> int:
+    def days(self, tz: datetime.tzinfo) -> int:
         """
         Return the number of days between the start and end of the range.
         """
-        return (self.end - self.start).days
+        range_ = self.localize(tz)
+        return (range_.end - range_.start).days
 
     @property
     def seconds(self) -> int:


### PR DESCRIPTION
It's possible to create mixed TZ FiniteDatetimeRange's. It probably shouldn't be, but it currently is and this is unlikely to change too soon. See https://github.com/octoenergy/xocto/issues/192

This makes the `FiniteDatetimeRange.days` property ambiguous. For example, should the below range be 31 or 30 days?

```py
RANGE = ranges.FiniteDatetimeRange(
    # This is also 2024-03-01T00:00:00 in TZ_UTC
    datetime.datetime(2024, 3, 1, tzinfo=TZ_LONDON),

    # This is 2024-04-01T00:00:00 in TZ_LONDON
    datetime.datetime(2024, 3, 31, hour=23, tzinfo=TZ_UTC),
)
```

Getting this wrong can lead to bugs in e.g. computation of per-day standing costs.

This PR updates `FiniteDatetimeRange.days` to require passing a TZ, to remove this ambiguity. This is a bit more verbose, but it's much more explicit and less error prone. 