### PR TITLE
Reverse order of `min` in `FiniteDatetimeRange.intersection`

### DIFF
--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -861,7 +861,7 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
             if left.end <= right.start:
                 return None
             else:
-                return FiniteDatetimeRange(right.start, min(left.end, right.end))
+                return FiniteDatetimeRange(right.start, min(right.end, left.end))
 
         base_intersection = super().intersection(other)
         if base_intersection is None:


### PR DESCRIPTION
In https://github.com/octoenergy/xocto/pull/187 the implementation of `FiniteDatetimeRange.intersection` was optimised. This introduced a very subtle change in behaviour. Previously when `left.end` was equal to `right.end` then the `right.end` was favoured. In https://github.com/octoenergy/xocto/pull/187 the implementation was (unintentionally) changed to favour `left.end`.

This change reverses that, to again favour `right.end`.

This really shouldn't matter, but it can be significant when the TZ of left and right are different. Eventually we'd like to prevent this kind of mixed TZ behaviour (see https://github.com/octoenergy/xocto/issues/192), but in the short term it seems reasonable to make this tiny change to make things consistent again with how they were before and in order to unblock xocto releases / install in Kraken.