### PR TITLE
Refer to ddtrace.tracer from a non deprecated location

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 license = {text = "MIT"}
 dependencies = [
-  "ddtrace>=1.9.0,<2.20.0",
+  "ddtrace>=2.20.0,<2.21.0",
   "duckdb>=0.9.0",
   "django>=4.0",
   "openpyxl>=3.1.0",

--- a/xocto/tracing.py
+++ b/xocto/tracing.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import ddtrace
+import ddtrace.trace
 
 
-tracer = ddtrace.tracer
+tracer = ddtrace.trace.tracer
 wrap = tracer.wrap
 
 


### PR DESCRIPTION
Prior to this the recent upgrade of ddtrace deprecated accessing tracer from ddtrace.

It is instead exported from ddtrace.trace now