### PR TITLE
Constrain ddtrace version to be <2.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 license = {text = "MIT"}
 dependencies = [
-  "ddtrace>=1.9.0",
+  "ddtrace>=1.9.0,<2.20.0",
   "duckdb>=0.9.0",
   "django>=4.0",
   "openpyxl>=3.1.0",


### PR DESCRIPTION
We're seeing errors in circleci for ddtrace v2.20.0. See https://app.circleci.com/pipelines/github/octoenergy/xocto/768/workflows/4444d76e-9a01-4683-a303-b240617d5bfd/jobs/746

We need to adapt xocto to support ddtrace v2.20.0, but we need to first make sure that Kraken is ready to support this version (Kraken is using v2.14.4).

In the meantime, just constrain the version of ddtrace within xocto.