### PR TITLE
Add `localtime.get_local_timezone()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `localtime.get_local_timezone()` [#206](https://github.com/octoenergy/xocto/pull/206/).
+
 ## V8.0.0 - 2025-02-05
 
 - Remove convenience code for ddtrace [#201](https://github.com/octoenergy/xocto/pull/201/).

--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -13,6 +13,10 @@ from tests import factories
 from xocto import localtime
 
 
+def test_get_local_timezone():
+    assert localtime.get_local_timezone() == timezone.get_current_timezone()
+
+
 class TestNow:
     def test_now_is_in_correct_timezone(self):
         now = localtime.now()

--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -28,6 +28,10 @@ ONE_HOUR = datetime_.timedelta(hours=1)
 MIDNIGHT_TIME = datetime_.time(0, 0)
 
 
+def get_local_timezone() -> datetime_.tzinfo:
+    return timezone.get_current_timezone()
+
+
 def as_localtime(
     dt: datetime_.datetime, tz: datetime_.tzinfo | None = None
 ) -> datetime_.datetime:


### PR DESCRIPTION
This PR adds `localtime.get_local_timezone()`. This avoids having to remember to import `django.utils.timezone` and call `timezone.get_current_timezone()`. It's only a small improvement, but it helps a little IMO.