### PR TITLE
Deprecate `FiniteDatetimeRange.days`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Mark `FiniteDatetimeRange.days` as deprecated [#207](https://github.com/octoenergy/xocto/pull/207).
 - Add `localtime.get_local_timezone()` [#206](https://github.com/octoenergy/xocto/pull/206/).
 
 ## V8.0.0 - 2025-02-05

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "python-magic>=0.4.27",
   "pytz",
   "structlog>=20.2.0",
+  "typing-extensions>=4.12.2",
   "xlrd>=2.0.1",
 ]
 

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -21,6 +21,7 @@ from typing import (
 )
 
 from dateutil import relativedelta
+from typing_extensions import deprecated
 
 from xocto.types import generic
 
@@ -934,6 +935,10 @@ class FiniteDatetimeRange(FiniteRange[datetime.datetime]):
         return self.union(other)
 
     @property
+    @deprecated(
+        "For midnight-aligned ranges get calendar days via `.as_date_range().days` instead. "
+        "Use `.localize()` first as appropriate."
+    )
     def days(self) -> int:
         """
         Return the number of days between the start and end of the range.


### PR DESCRIPTION
See issue https://github.com/octoenergy/xocto/issues/192 for context.

I think it makes sense to mark this property as deprecated before removing it - there are quite a number uses in Kraken and other users of xocto may also use this function. 

By deprecating the function:
* Users will see a warning in most IDEs when using using this function, hinting them what to use instead.
* Warnings will appear when this function is used in tests (https://docs.pytest.org/en/stable/how-to/capture-warnings.html)
* It is possible to lint for cases where the deprecated function is used with mypy. 