### PR TITLE
Start storing benchmarks data

### DIFF
--- a/.github/workflows/collect_benchmarks.yml
+++ b/.github/workflows/collect_benchmarks.yml
@@ -1,0 +1,45 @@
+name: Collect benchmarks
+
+on:
+  workflow_run:
+    workflows: [ "Run benchmarks main" ]
+    types:
+      - completed
+
+# `concurrency` used to ensure that only one instance of this workflow runs at one time.
+# This is important since concurrent workflows would operate on the same files.
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  collect_benchmarks:
+    name: Collect benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout benchmarks-data branch
+        uses: actions/checkout@v4
+        with:
+          ref: benchmarks-data
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Collect benchmarks
+        run: uv run scripts/collect_benchmarks.py -i 'uncollected/*.csv' -o benchmarks.csv
+
+      - name: Remove now collected benchmarks
+        run: rm uncollected/*.csv
+
+      - name: Add and commit
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          
+          git add --all
+          git commit -m "Collect benchmarks"
+          
+          # Retry below incase another workflow pushed to the benchmarks-data branch since we checked it out.
+          # Unlikely but technically possible...
+          # There won't be a merge conflict since this workflow is the only workflow touching benchmarks.csv
+          # and this workflow uses `concurrency`.
+          scripts/push_with_retry.sh 5

--- a/.github/workflows/run_benchmarks_main.yml
+++ b/.github/workflows/run_benchmarks_main.yml
@@ -1,0 +1,76 @@
+name: Run benchmarks main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run_benchmarks:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Run benchmarks
+        run: pytest --benchmark-only --benchmark-json benchmarks.json
+
+      - name: Upload artifact - benchmarks JSON
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmarks_json
+          path: benchmarks.json
+          # Short retention. Only needed short term to share with the `extract_benchmarks` job.
+          retention-days: 1
+
+  extract_benchmarks:
+    name: Extract benchmarks
+    runs-on: ubuntu-latest
+    needs: [ run_benchmarks ]
+    steps:
+      - name: Checkout benchmarks-data branch
+        uses: actions/checkout@v4
+        with:
+          ref: benchmarks-data
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Download artifact - benchmarks JSON
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmarks_json
+
+      - name: Extract benchmarks
+        run: |
+          uv run scripts/extract_benchmarks.py \
+            -i benchmarks.json \
+            -o "uncollected/$(uuidgen).csv" \
+            -t ubuntu-latest
+
+      - name: Remove benchmarks JSON
+        run: rm benchmarks.json
+
+      - name: Add and commit benchmarks data
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          
+          git add --all
+          git commit -m "Add uncollected benchmarks"
+
+          # Retry below incase another workflow pushed to the benchmarks-data branch since we checked it out.
+          # Unlikely but technically possible...
+          # There won't be a merge conflict since we used a UUID as the file name.
+          scripts/push_with_retry.sh 5


### PR DESCRIPTION
As part of performance work for costing, we added some benchmarks to xocto (for the ranges module). These benchmarks were useful to measure our improvements locally. However they are not being run in CI and we're not keeping a record of the results over time. So they only have limited use right now.

This PR proposes a very lightweight solution to start running benchmarks in CI and storing the results.

* A GitHub workflow to run benchmarks on every push to `main` and store the results as a CSV in a dedicated `benchmarks-data` branch.
* A GitHub workflow to collect benchmark result CSVs into a single, consolidated CSV living on the `benchmarks-data` branch.

Given the above workflows, it would make sense to make `benchmarks-data` a protected branch.

For the purpose of this PR we don't do anything with the benchmark results CSV living on the `benchmarks-data` branch. In the future we might like to do things like:
* Create absolute or relative thresholds for the benchmarks (e.g. defined in a config file) and then alert interested parties if those thresholds are crossed (e.g. slack channel with benchmark alerts).
* Create another workflow to run benchmarks on PRs and use the results from main to compare. Was there a regression/improvement? We can automatically leave a comment on the PR to flag any issues or even fail the build.
* Analyse the data e.g. change point detection.

Basically, once we start collecting some data there are lots of options for how to take this further and make it more useful.

I've already created the `benchmarks-data` branch here https://github.com/octoenergy/xocto/tree/benchmarks-data.

Why this custom approach?. Why not use a 3rd party service? True. I have been looking into https://codspeed.io/ and https://bencher.dev/ as alternatives. There are a few issues here:
* Main issue: They cost quite a bit of money (actually, for open source projects they are free, but I'm only using xocto as a testing ground. I am really hoping eventually to take this approach and apply it to benchmarks in Kraken).
* Neither platform seems to be quite ideal. I've tested both out and they seem pretty good, but I'm not sure we want to commit to using either.

If we do decide we want to use one of these third party solutions later that's also fine - we can quickly delete this custom solution. I.e. we're not backing ourselves into a corner here at all.

The approach taken here is somewhat inspired by https://github.com/benchmark-action/github-action-benchmark.

For general information about benchmarking in python see https://pytest-benchmark.readthedocs.io/en/latest/.

I've already tested this approach out on my fork https://github.com/Peter554/xocto. See:
* The workflow that runs the benchmarks https://github.com/Peter554/xocto/actions/runs/13653420832
* The workflow that collects the benchmarks https://github.com/Peter554/xocto/actions/runs/13653453022
* The benchmarks data file that is generated on the `benchmarks-data` branch https://github.com/Peter554/xocto/blob/benchmarks-data/benchmarks.csv