### PR TITLE
Allow for `FiniteDatetimeRange` to be considered as "half-open"

### DIFF
--- a/xocto/fields/postgres/ranges.py
+++ b/xocto/fields/postgres/ranges.py
@@ -188,7 +188,7 @@ class HalfFiniteDateTimeRangeField(_LocaliserMixin, pg_fields.DateTimeRangeField
         if isinstance(value, datetime.datetime):
             return value
         raise TypeError(
-            "HalfFiniteDateTimeRangeField may only accept HalfFiniteDateTimeRangeField or datetime objects."
+            "HalfFiniteDateTimeRangeField may only accept HalfFiniteDateTimeRangeField, FiniteDateTimeRangeField, or datetime objects."
         )
 
     def from_db_value(

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -1234,7 +1234,14 @@ def _is_datetime_range(value: Any) -> bool:
     )
 
 
+def _is_datetime_range_and_bounded(value: Any) -> bool:
+    return _is_datetime_range(value) and (
+        isinstance(value.start, datetime.datetime)
+        or isinstance(value.end, datetime.datetime)
+    )
+
+
 # Subscripted generics may not be used with isinstance directly.
 # TODO: A TypeGuard would be nicer, once we drop Python 3.9.
 def _is_half_finite_datetime_range(value: Any) -> bool:
-    return _is_datetime_range(value) and isinstance(value, HalfFiniteRange)
+    return _is_datetime_range_and_bounded(value) or isinstance(value, HalfFiniteRange)


### PR DESCRIPTION
`_is_half_finite_datetime_range` currently checks whether that passed
item is indeed a `HalfFiniteRange`. We change the implementation to allow
for both `HalfFiniteRange` and `FiniteDatetimeRange` to be passed in and
treated as the same item. This is because a `HalfFiniteRange` is a
a superset of `FiniteDatetimeRange` and we want to allow for both
types to be passed in and treated as the same item.
