### PR TITLE
Bump version to v8.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## V8.1.1 - 2025-07-28
+
+- Fix spanish month translation typo [#217](https://github.com/octoenergy/xocto/pull/217).
+
 ## V8.1.0 - 2025-02-18
 
 - Mark `FiniteDatetimeRange.days` as deprecated [#207](https://github.com/octoenergy/xocto/pull/207).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xocto"
-version = "8.1.0"
+version = "8.1.1"
 requires-python = ">=3.9"
 description = "Kraken Technologies Python service utilities"
 readme = "README.md"


### PR DESCRIPTION
Following the publishing [instructions](https://xocto.readthedocs.io/en/latest/xocto/development.html#publishing) to release the typo fix from #217. Patch version increased given previous PRs were done on private code that don't seem to require updating the version for.