### PR TITLE
Implement `iterate_over_days` functionality in `ranges`

### DIFF
--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -1538,6 +1538,104 @@ class TestIterateOverMonths:
         assert result == row["expected"]
 
 
+class TestIterateOverDays:
+    @pytest.mark.parametrize(
+        "row",
+        [
+            {
+                "period": ranges.FiniteDatetimeRange(
+                    datetime.datetime(2023, 6, 12, 3, 45, tzinfo=localtime.UTC),
+                    datetime.datetime(2023, 6, 12, 16, 15, tzinfo=localtime.UTC),
+                ),
+                "expected": [
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2023, 6, 12, 3, 45, tzinfo=localtime.UTC),
+                        datetime.datetime(2023, 6, 12, 16, 15, tzinfo=localtime.UTC),
+                    )
+                ],
+                "id": "within-one-day",
+            },
+            {
+                "period": ranges.FiniteDatetimeRange(
+                    datetime.datetime(2021, 5, 12, 2, 30, tzinfo=localtime.UTC),
+                    datetime.datetime(2021, 5, 13, 18, 25, tzinfo=localtime.UTC),
+                ),
+                "expected": [
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2021, 5, 12, 2, 30, tzinfo=localtime.UTC),
+                        datetime.datetime(2021, 5, 13, tzinfo=localtime.UTC),
+                    ),
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2021, 5, 13, tzinfo=localtime.UTC),
+                        datetime.datetime(2021, 5, 13, 18, 25, tzinfo=localtime.UTC),
+                    ),
+                ],
+                "id": "spanning-two-days",
+            },
+            {
+                "period": ranges.FiniteDatetimeRange(
+                    datetime.datetime(2021, 5, 12, 5, 10, tzinfo=localtime.UTC),
+                    datetime.datetime(2021, 5, 14, 17, 55, tzinfo=localtime.UTC),
+                ),
+                "expected": [
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2021, 5, 12, 5, 10, tzinfo=localtime.UTC),
+                        datetime.datetime(2021, 5, 13, tzinfo=localtime.UTC),
+                    ),
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2021, 5, 13, tzinfo=localtime.UTC),
+                        datetime.datetime(2021, 5, 14, tzinfo=localtime.UTC),
+                    ),
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2021, 5, 14, tzinfo=localtime.UTC),
+                        datetime.datetime(2021, 5, 14, 17, 55, tzinfo=localtime.UTC),
+                    ),
+                ],
+                "id": "spanning-three-days",
+            },
+            {
+                "period": ranges.FiniteDatetimeRange(
+                    datetime.datetime(2021, 5, 31, 2, 30, tzinfo=localtime.UTC),
+                    datetime.datetime(2021, 6, 1, 18, 25, tzinfo=localtime.UTC),
+                ),
+                "expected": [
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2021, 5, 31, 2, 30, tzinfo=localtime.UTC),
+                        datetime.datetime(2021, 6, 1, tzinfo=localtime.UTC),
+                    ),
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2021, 6, 1, tzinfo=localtime.UTC),
+                        datetime.datetime(2021, 6, 1, 18, 25, tzinfo=localtime.UTC),
+                    ),
+                ],
+                "id": "spanning-two-days-over-month-boundary",
+            },
+            {
+                "period": ranges.FiniteDatetimeRange(
+                    datetime.datetime(2021, 12, 31, 2, 30, tzinfo=localtime.UTC),
+                    datetime.datetime(2022, 1, 1, 18, 25, tzinfo=localtime.UTC),
+                ),
+                "expected": [
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2021, 12, 31, 2, 30, tzinfo=localtime.UTC),
+                        datetime.datetime(2022, 1, 1, tzinfo=localtime.UTC),
+                    ),
+                    ranges.FiniteDatetimeRange(
+                        datetime.datetime(2022, 1, 1, tzinfo=localtime.UTC),
+                        datetime.datetime(2022, 1, 1, 18, 25, tzinfo=localtime.UTC),
+                    ),
+                ],
+                "id": "spanning-two-days-over-year-boundary",
+            },
+        ],
+        ids=lambda row: row["id"],
+    )
+    def test_yields_correct_ranges(self, row):
+        result = list(ranges.iterate_over_days(period=row["period"], tz=localtime.UTC))
+
+        assert result == row["expected"]
+
+
 def _rangeset_from_string(rangeset_str: str) -> ranges.RangeSet[int]:
     """
     Convenience method to make test declarations clearer.

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -1175,11 +1175,45 @@ def iterate_over_months(
         (01/03->15/03)
     ]
     """
+    return _iterate_over_periods(
+        period=period, tz=tz, delta=relativedelta.relativedelta(months=1, day=1)
+    )
+
+
+def iterate_over_days(
+    period: FiniteDatetimeRange, *, tz: datetime.tzinfo
+) -> Iterator[FiniteDatetimeRange]:
+    """
+    Generate a sequence of finite datetime ranges spanning days during the period.
+
+    Ranges span each whole day between the start and end times, inclusive.
+
+    ie: given a period of (2025-01-15 10:30, 2025-01-17 09:00) -> [
+        (2025-01-15 10:30->2025-01-16 00:00),
+        (2025-01-16 00:00->2025-01-17 00:00),
+        (2025-01-17 00:00->2025-01-17 09:00)
+    ]
+    """
+    return _iterate_over_periods(
+        period=period,
+        tz=tz,
+        delta=relativedelta.relativedelta(
+            days=1, hour=0, minute=0, second=0, microsecond=0
+        ),
+    )
+
+
+def _iterate_over_periods(
+    period: FiniteDatetimeRange,
+    *,
+    tz: datetime.tzinfo,
+    delta: relativedelta.relativedelta,
+) -> Iterator[FiniteDatetimeRange]:
     start_at = localtime.as_localtime(period.start, tz=tz)
     end_at = localtime.as_localtime(period.end, tz=tz)
 
     while True:
-        next_start = start_at + relativedelta.relativedelta(months=1, day=1)
+        next_start = start_at + delta
         this_end = next_start
 
         if end_at <= this_end:


### PR DESCRIPTION
This functionality will generate a sequence of finite datetime ranges spanning days during the period.
Ranges span each whole day between the start and end times, inclusive.