### PR TITLE
Replace magic numbers with domain constants

### DIFF
--- a/xocto/settlement_periods.py
+++ b/xocto/settlement_periods.py
@@ -1,7 +1,7 @@
 import datetime
 import typing
 
-import pytz
+import pytz  # type: ignore[import-untyped]  # TODO: Remove when pytz dependency removed
 
 from . import exceptions
 


### PR DESCRIPTION
## Summary

This PR refactors `settlement_periods.py` to enhance readability and maintainability by replacing hard-coded magic numbers with named constants documenting UK energy market settlement-period rules.

## What has been changed?

**Introduced constants capturing settlement-period business rules:**

- `SETTLEMENT_PERIODS_PER_DAY = 48` – standard periods per normal trading day.
- `SETTLEMENT_PERIOD_MINUTES = 30` – explicit standard interval.
- `WHOLESALE_MARKET_START_HOUR = 23` – wholesale trading start time.
- `RETAIL_MARKET_START_HOUR = 24` – conceptual retail trading start time (midnight), used only for offset calculation
- `SETTLEMENT_PERIODS_DST_FALLBACK_EXTRA = 2` – extra hour creates 2 additional 30-minute periods.
- `SETTLEMENT_PERIODS_PER_DAY_MAX = SETTLEMENT_PERIODS_PER_DAY + SETTLEMENT_PERIODS_DST_FALLBACK_EXTRA` –  maximum periodus during DST fallback

**Replaced magic numbers throughout:**

- `hour >= 23` → `hour >= WHOLESALE_MARKET_START_HOUR`
- `minute < 30` → `minute < SETTLEMENT_PERIOD_MINUTES`
- `range(1, 51)` → `range(1, SETTLEMENT_PERIODS_PER_DAY_MAX + 1)`
- `minutes=30 * (sp - 1)` → `minutes=SETTLEMENT_PERIOD_MINUTES * (sp - 1)`
- All related time calculations reference named constants.

**Temporary build fix**

- Added temporary `type: ignore` annotation for `pytz` import to resolve pre-commit `mypy` checks.
- Aligned with the project's ongoing removal of `pytz`
- See references commit [81a05be](https://github.com/octoenergy/xocto/commit/81a05be633ac68898b7d8b7c8f93b4d824064c54)

## Why these changes?

**Benefits:**

- **Self-documenting code:** constants explicitly provide business context and capture domain.
- **Improved maintainability:** Updating rules now involves adjusting constants, not searching for magic numbers.

**Rationale for literal '1' retention:**

The literal value `1` is retained in three scenarios:

- `timedelta(days=1)`
  - Represents a fixed business rule (wholesale periods 23:00–23:59 belong to the next day).

- `range(1, SETTLEMENT_PERIODS_PER_DAY_MAX + 1)`
  - Couting starts at `1,` not zero, so the value is obvious.
  - A `FIRST_SETTLEMENT_PERIOD` constant would provide no extra information

- `(sp - 1)`
  - Standard conversion from 1-based period numbers to zero-based indexes.

## Testing done

- All existing unit tests passing.
- Pre-commit hooks (`mypy`, `ruff`, formatting) pass successfully.
- No functional changes; purely refactoring.

## Future work

- Removal of `pytz` dependency and related temporary `type: ignore` annotation in an upcoming PR, continuing the initiative from [81a05be](https://github.com/octoenergy/xocto/commit/81a05be633ac68898b7d8b7c8f93b4d824064c54).

## Review guidance

Please focus your review on:

- Clarity and appropriateness of constant naming.
- Completeness of magic number replacement.
- Whether this refactoring delivers the claimed maintainability and readability benefits.