### PR TITLE
Draft: settings refactor

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,10 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
 ]
+
+intersphinx_mapping = {"python": ("https://botocore.readthedocs.io/en/latest/", None)}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ PyPI detail page: https://pypi.python.org/pypi/xocto
    xocto/settlement_periods
    xocto/storage
    xocto/types
+   xocto/settings
    xocto/development
 
 

--- a/docs/xocto/settings.md
+++ b/docs/xocto/settings.md
@@ -1,0 +1,10 @@
+# Settings
+
+```{eval-rst}
+.. automodule:: xocto.conf
+   :no-index:
+
+.. autoclass:: XoctoSettings
+   :members:
+   :undoc-members:
+```

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,0 +1,28 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import SystemCheckError
+from django.test import override_settings
+
+
+def run_system_checks() -> str:
+    stderr = StringIO()
+    call_command("check", "-t", "xocto", deploy=True, stderr=stderr)
+    return stderr.getvalue()
+
+
+def test_valid_settings():
+    output = run_system_checks()
+    assert "xocto.E001" not in output
+    assert "xocto.W001" not in output
+
+
+@override_settings(BOTO_S3_TOTAL_MAX_ATTEMPTS="notanint")
+def test_incorrect_setting_type():
+    with pytest.raises(SystemCheckError) as exc_info:
+        run_system_checks()
+    assert (
+        "(xocto.E001) settings.BOTO_S3_TOTAL_MAX_ATTEMPTS is the wrong type: expected NoneType/int, got str"
+        in exc_info.value.args[0]
+    )

--- a/xocto/apps.py
+++ b/xocto/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+from django.core import checks
+
+
+class XoctoAppConfig(AppConfig):
+    name = "xocto"
+
+    def ready(self) -> None:
+        from xocto.conf import check_settings
+
+        checks.register(check_settings, "xocto", deploy=True)

--- a/xocto/conf.py
+++ b/xocto/conf.py
@@ -1,0 +1,115 @@
+"""
+The settings for the ``xocto`` package. This acts as a proxy to
+``django.conf.settings`` and provides a way for us to set accurate types and
+defaults.
+"""
+
+import dataclasses
+from typing import Any, List, Optional, Union, get_args, get_origin
+
+from django.apps import AppConfig
+from django.conf import settings as django_settings
+from django.core import checks
+
+
+@dataclasses.dataclass(frozen=True, init=False, repr=False)
+class XoctoSettings:
+    """Access this instance as ``xocto.conf.settings``"""
+
+    BOTO_S3_CONNECT_TIMEOUT: Optional[Union[float, int]] = None
+    """
+    Connect timeout in seconds for S3. If the value is not ``None``, it's passed
+    as the ``connect_timeout`` parameter to :py:class:`botocore.config.Config`,
+    otherwise the default is used.
+    """
+
+    BOTO_S3_READ_TIMEOUT: Optional[Union[float, int]] = None
+    """
+    Read timeout in seconds for S3. If the value is not ``None``, it's passed
+    as the ``read_timeout`` parameter to :py:class:`botocore.config.Config`,
+    otherwise the default is used.
+    """
+
+    BOTO_S3_TOTAL_MAX_ATTEMPTS: Optional[int] = None
+    """
+    The total number of attempts to make for a particular request to S3,
+    including the initial request.  If the value is not ``None``, it's passed as
+    the value of the  ``"total_max_attempts"`` key of the ``retries`` parameter
+    to :py:class:`botocore.config.Config`.
+    """
+
+    # TODO: these are the other settings that xocto refers to, go through them
+    # and work out which ones are xocto-specific and add types and defaults as
+    # needed:
+    # - AWS_AUTO_SCALING_GROUP
+    # - AWS_AVAILABILITY_ZONE
+    # - AWS_INSTANCE_ID
+    # - AWS_LOCAL_IP
+    # - AWS_REGION
+    # - AWS_S3_ENDPOINT_URL
+    # - DOCUMENT_STORAGE_BACKEND
+    # - EMAIL_STORAGE_BACKEND
+    # - EMAIL_STORAGE_ROOT
+    # - GIT_SHA
+    # - INTEGRATION_FLOW_S3_OUTBOUND_BUCKET
+    # - LINE_INBOUND_ATTACHMENTS_BUCKET
+    # - MEDIA_ROOT
+    # - MEDIA_URL
+    # - S3_ARCHIVE_BUCKET
+    # - S3_FILESERVER_BUCKET
+    # - S3_PRODUCTION_FLOWS_OUTBOUND
+    # - S3_SUPPORT_DOCUMENTS_BUCKET
+    # - S3_USER_DOCUMENTS_BUCKET
+    # - S3_USER_MEDIA_BUCKET
+    # - S3_VOICE_AUDIO_BUCKET
+    # - STORAGE_BACKEND
+
+    def __getattribute__(self, name: str) -> Any:
+        """
+        If a setting is defined in the Django settings, return it from there.
+        Otherwise, return the default value from this class.
+        """
+        if name in _setting_names:
+            try:
+                return getattr(django_settings, name)
+            except AttributeError:
+                pass
+        return super().__getattribute__(name)
+
+
+_setting_names = {f.name for f in dataclasses.fields(XoctoSettings)}
+
+
+settings = XoctoSettings()
+
+
+def check_settings(
+    app_configs: Optional[List[AppConfig]], **kwargs: object
+) -> List[checks.CheckMessage]:
+    """
+    A system check that ensures that the values of any Django settings
+    referenced by xocto have the correct types.
+    """
+    messages: List[checks.CheckMessage] = []
+
+    for field in dataclasses.fields(XoctoSettings):
+        value = getattr(settings, field.name)
+
+        if (origin := get_origin(field.type)) is not None:
+            if origin is Union:
+                value_types = get_args(field.type)
+            else:
+                raise TypeError("Unexpected origin type for generic settings field")
+        else:
+            value_types = (field.type,)
+
+        if not isinstance(value, value_types):
+            messages.append(
+                checks.Error(
+                    f"settings.{field.name} is the wrong type: expected {'/'.join(sorted(t.__name__ for t in value_types))}, got {type(value).__name__}",
+                    hint="If the value is read from an environment variable as a string, ensure it's validated and converted to the correct type in the settings module",
+                    id="xocto.E001",
+                )
+            )
+
+    return messages

--- a/xocto/storage/storage.py
+++ b/xocto/storage/storage.py
@@ -19,6 +19,7 @@ from typing import (
     Any,
     AnyStr,
     BinaryIO,
+    Dict,
     Iterable,
     Iterator,
     Protocol,
@@ -40,6 +41,7 @@ from django.utils.module_loading import import_string
 from pyarrow import parquet
 
 from xocto import events, localtime
+from xocto.conf import settings as xocto_settings
 
 from . import files, s3_select
 
@@ -809,19 +811,15 @@ class S3FileStore(BaseS3FileStore):
         return None
 
     def _get_boto_client(self) -> S3Client:
-        config = {}
+        config: Dict[str, Any] = {}
 
-        if (
-            connect_timeout := getattr(settings, "BOTO_S3_CONNECT_TIMEOUT")
-        ) is not None:
-            config["connect_timeout"] = connect_timeout
-        if (read_timeout := getattr(settings, "BOTO_S3_READ_TIMEOUT")) is not None:
-            config["read_timeout"] = read_timeout
-        if (
-            total_max_attempts := getattr(settings, "BOTO_S3_TOTAL_MAX_ATTEMPTS")
-        ) is not None:
+        if xocto_settings.BOTO_S3_CONNECT_TIMEOUT is not None:
+            config["connect_timeout"] = xocto_settings.BOTO_S3_CONNECT_TIMEOUT
+        if xocto_settings.BOTO_S3_READ_TIMEOUT is not None:
+            config["read_timeout"] = xocto_settings.BOTO_S3_READ_TIMEOUT
+        if xocto_settings.BOTO_S3_TOTAL_MAX_ATTEMPTS is not None:
             config["retries"] = {
-                "total_max_attempts": total_max_attempts,
+                "total_max_attempts": xocto_settings.BOTO_S3_TOTAL_MAX_ATTEMPTS,
             }
 
         return boto3.client(


### PR DESCRIPTION
This WIP PR is based on [this pattern](https://overtag.dk/v2/blog/a-settings-pattern-for-reusable-django-apps/) for adding types, default and docs for settings for reusable Django apps.

It add a pseudo-immutable `XoctoSettings` class that acts as a namespace for the Django settings that `xocto` cares about and is somewhere to provide documentation, type information and defaults for those settings. It also adds a deployment check that validates that the settings have the correct type. I guess that could also be extended to validating the _values_ of the settings, but currently it doesn't. This is motivated by the [oegb-widespread-type-errors](https://rootly.com/account/incidents/11b6329b-543a-4c7d-90e8-90a58f148f88) incident, where incorrect settings types only threw errors at runtime and caused nearly all S3 communication to fail.

The generated documentation looks like this: 

<img width="1100" height="851" alt="image" src="https://github.com/user-attachments/assets/d9c94124-a5cf-4300-a2a3-9d49245d4e5f" />

*Issues I know about already:*
- For this to work, `xocto` needs to be added to `INSTALLED_APPS`. This happens in the test project in this repo, but not in `kraken-core` (and I assume many other projects that use `xocto`)
- For the system check to actually protect us against deploying with broken settings, we'd need to run `django-admin check --deploy` in our pipelines/healthchecks, which as far as I'm able to see we don't. If there's a reason why we don't then this might be a non-starter.

*Outstanding work:*
- Figure out which settings referenced in the code belong to `xocto` and add them to the `XoctoSettings` class
