### PR TITLE
Ensure that django settings are integers when populating boto config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Ensure that boto configuration from django settings are integers [#231](https://github.com/octoenergy/xocto/pull/231)
+
 ## V8.4.0 - 2025-09-02
 
 - Add `DjangoJSONValue` Django type [#232](https://github.com/octoenergy/xocto/pull/232)


### PR DESCRIPTION
Prior to this change, we were getting settings from django.conf.settings but we weren't ensuring they are integers.

This raises the risk that boto is given strings when it expects integers.

It is also made much easier to override the boto config that the file store uses.