### PR TITLE
Fix broken github action by creating venv

### DIFF
--- a/.github/workflows/run_benchmarks_main.yml
+++ b/.github/workflows/run_benchmarks_main.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Set up virtual environment
+        run: |
+          python -m venv venv
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/venv" >> $GITHUB_ENV
+
       - name: Install dependencies
         run: make install
 


### PR DESCRIPTION
Changing `make install` to `uv` broke a github action, because `uv` expects a `venv`. 

This creates that `venv`.