### PR TITLE
Fix broken github action 2 by adding venv bin to path

### DIFF
--- a/.github/workflows/run_benchmarks_main.yml
+++ b/.github/workflows/run_benchmarks_main.yml
@@ -29,7 +29,7 @@ jobs:
         run: make install
 
       - name: Run benchmarks
-        run: pytest --benchmark-only --benchmark-json benchmarks.json
+        run: python -m pytest --benchmark-only --benchmark-json benchmarks.json
 
       - name: Upload artifact - benchmarks JSON
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The github action was still broken due to not finding pytest, so adding the path is also needed.