### PR TITLE
Bump Version to v8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## V8.4.0 - 2025-09-02
+
+- Add `DjangoJSONValue` Django type [#232](https://github.com/octoenergy/xocto/pull/232)
+- Add `DjangoJSONSerializableValue` Django type [#232](https://github.com/octoenergy/xocto/pull/232)
+
 ## V8.3.1 - 2025-09-02
 
 - Inline import of `pandas` and `duckdb` [#237](https://github.com/octoenergy/xocto/pull/237)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xocto"
-version = "8.3.1"
+version = "8.4.0"
 requires-python = ">=3.9"
 description = "Kraken Technologies Python service utilities"
 readme = "README.md"


### PR DESCRIPTION
## v8.4.0

As per [instructions](https://xocto.readthedocs.io/en/latest/xocto/development.html#publishing), bump the version of xocto due to recently deployed changes: https://github.com/octoenergy/xocto/pull/232
