### PR TITLE
Ensure we create the boto config when passing that into boto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## V8.5.1 - 2025-09-03
+
 - Ensure we create the boto config when passing that into boto [#242](https://github.com/octoenergy/xocto/pull/242)
 
 ## V8.5.0 - 2025-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Ensure we create the boto config when passing that into boto [#242](https://github.com/octoenergy/xocto/pull/242)
+
 ## V8.5.0 - 2025-09-03
 
 - Ensure that boto configuration from django settings are integers [#231](https://github.com/octoenergy/xocto/pull/231)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xocto"
-version = "8.5.0"
+version = "8.5.1"
 requires-python = ">=3.9"
 description = "Kraken Technologies Python service utilities"
 readme = "README.md"

--- a/xocto/storage/storage.py
+++ b/xocto/storage/storage.py
@@ -880,7 +880,7 @@ class S3FileStore(BaseS3FileStore):
             "s3",
             region_name=settings.AWS_REGION,
             endpoint_url=settings.AWS_S3_ENDPOINT_URL,
-            config=self._get_boto_config,
+            config=self._get_boto_config(),
         )
 
     def _get_boto_bucket(self) -> service_resource.Bucket:


### PR DESCRIPTION
Prior to this we created a new way of getting the boto config but when we used that new way to create the config we didn't use it properly and passed in the factory rather than the result.

This change fixes that