### PR TITLE
Remove dependency from ranges module on localtime module

### DIFF
--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -25,8 +25,6 @@ from typing_extensions import deprecated
 
 from xocto.types import generic
 
-from . import localtime
-
 
 class RangeBoundaries(enum.Enum):
     EXCLUSIVE_EXCLUSIVE = "()"
@@ -1209,8 +1207,8 @@ def _iterate_over_periods(
     tz: datetime.tzinfo,
     delta: relativedelta.relativedelta,
 ) -> Iterator[FiniteDatetimeRange]:
-    start_at = localtime.as_localtime(period.start, tz=tz)
-    end_at = localtime.as_localtime(period.end, tz=tz)
+    start_at = period.start.astimezone(tz)
+    end_at = period.end.astimezone(tz)
 
     while True:
         next_start = start_at + delta


### PR DESCRIPTION
# Why is this change needed?
Prior to this change, the ranges module had a dependency on the
localtime module, which was only used for a single function call to
localtime.as_localtime that wraps django.utils.timezone.localtime.

# How does it address the issue?
This change removes the dependency. This should make it possible to
import xocto.ranges locally without Django running (which will speed up
some local testing).