### PR TITLE
Temporarily ignore typing for duckdb

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,6 +20,7 @@ benchmark:
 	py.test  --benchmark-only --benchmark-autosave --benchmark-compare --benchmark-group-by=func --benchmark-columns mean,rounds,iterations
 
 mypy:
+	mypy --version
 	mypy
 
 # Local helpers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,8 @@ module = [
   "boto3.*",
   "botocore.*",
   "django.*",
+  # TODO: Remove after https://github.com/duckdb/duckdb-python/issues/57 is resolved
+  "duckdb.*",
   "moto.*",
   "pact.*",
   "pandas.*",


### PR DESCRIPTION
Duckdb has accidentally removed typing support in the latest version
(https://github.com/duckdb/duckdb-python/issues/57).

This change removes it from our type checking for the moment so that CI can
continue to pass.