### PR TITLE
Update minimum pact-python version to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "duckdb>=0.9.0",
   "django>=4.0",
   "openpyxl>=3.1.0",
-  "pact-python>=1.6.0,<3.0.0",
+  "pact-python[compat-v2]>=3.0.0",
   "pandas>=1.5.3",
   "pyarrow>=11.0.0",
   "python-dateutil>=2.8.2",
@@ -212,7 +212,7 @@ filterwarnings = [
     "ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3:DeprecationWarning:(graphene|singledispatch)",
     # https://github.com/ktosiek/pytest-freezegun/issues/35
     "ignore:distutils Version classes are deprecated:DeprecationWarning:pytest_freezegun",
-    "ignore:This class will be deprecated Pact Python v3:PendingDeprecationWarning",
+    "ignore:The `pact.v2` module is deprecated:DeprecationWarning",
     # --- Python 3.12
     'ignore:datetime\.datetime\.utcnow\(\) is deprecated:DeprecationWarning',
     'ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated:DeprecationWarning',

--- a/xocto/pact_testing.py
+++ b/xocto/pact_testing.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from typing import Any
 
-import pact
+import pact.v2 as pact_v2
 import requests
 
 
@@ -41,13 +41,13 @@ class PactConsumerClient:
         return response.json()
 
 
-def pact_service(*, options: PactOptions, publish_to_broker: bool) -> pact.Pact:
-    service = pact.Consumer(
+def pact_service(*, options: PactOptions, publish_to_broker: bool) -> pact_v2.Pact:
+    service = pact_v2.Consumer(  # type: ignore[no-untyped-call]
         name=options.consumer_name,
         tag_with_git_branch=True,
         version=options.consumer_version,
     ).has_pact_with(
-        pact.Provider(options.provider_name),
+        pact_v2.Provider(options.provider_name),  # type: ignore[no-untyped-call]
         publish_to_broker=publish_to_broker,
         broker_base_url=options.broker_url,
         broker_username=options.broker_username,


### PR DESCRIPTION
This library had some breaking changes, but we will continue to use the v2 compatibility for the time being