### PR TITLE
Contracts: add ensure_midnight_aligned helper to localtime

### DIFF
--- a/tests/test_localtime.py
+++ b/tests/test_localtime.py
@@ -1210,6 +1210,74 @@ class TestParseDatetime:
         assert "Invalid isoformat string" in str(exc_info.value)
 
 
+class TestEnsureMidnightAligned:
+    def test_returns_none_for_none(self):
+        assert localtime.ensure_midnight_aligned(None) is None
+
+    def test_returns_midnight_for_date(self):
+        date = datetime.date(2026, 4, 16)
+        assert localtime.ensure_midnight_aligned(date) == localtime.midnight(date)
+
+    @pytest.mark.parametrize(
+        "source_datetime, expected_midnight",
+        [
+            (
+                # Naive datetime
+                datetime.datetime(2026, 4, 16, 14, 30),
+                localtime.midnight(datetime.datetime(2026, 4, 16)),
+            ),
+            (
+                # Local TZ-aware datetime
+                factories.local.dt("2026-04-16 14:30"),
+                localtime.midnight(datetime.date(2026, 4, 16)),
+            ),
+            (
+                # UTC datetime
+                factories.utc.dt("2026-04-16 14:30"),
+                localtime.midnight(datetime.date(2026, 4, 16)),
+            ),
+        ],
+    )
+    def test_returns_midnight_for_datetime(self, source_datetime, expected_midnight):
+        assert localtime.ensure_midnight_aligned(source_datetime) == expected_midnight
+
+    @pytest.mark.parametrize(
+        "source_datetime, expected_midnight",
+        [
+            (
+                # UTC 22:30 during BST (London is UTC+1): local time is 23:30 on Jun 1, no date rollover
+                factories.utc.dt("2026-06-01 22:30"),
+                localtime.midnight(datetime.date(2026, 6, 1)),
+            ),
+            (
+                # UTC 23:30 during BST (London is UTC+1): local time is 00:30 on Jun 2, date rolls over
+                factories.utc.dt("2026-06-01 23:30"),
+                localtime.midnight(datetime.date(2026, 6, 2)),
+            ),
+            (
+                # UTC 23:30 outside BST (London = UTC, no offset): local date stays Dec 1
+                factories.utc.dt("2026-12-01 23:30"),
+                localtime.midnight(datetime.date(2026, 12, 1)),
+            ),
+            (
+                # Fall back (Oct 25, 2026): UTC 23:30 on Oct 24 = BST 00:30 on Oct 25, date rolls over
+                factories.utc.dt("2026-10-24 23:30"),
+                localtime.midnight(datetime.date(2026, 10, 25)),
+            ),
+            (
+                # Fall back (Oct 25, 2026): UTC 23:30 on Oct 25 = GMT 23:30 (clocks have gone back), no rollover
+                factories.utc.dt("2026-10-25 23:30"),
+                localtime.midnight(datetime.date(2026, 10, 25)),
+            ),
+        ],
+    )
+    @override_settings(TIME_ZONE="Europe/London")
+    def test_returns_midnight_for_utc_datetime(
+        self, source_datetime, expected_midnight
+    ):
+        assert localtime.ensure_midnight_aligned(source_datetime) == expected_midnight
+
+
 class TestStrftime:
     @override_settings(TIME_ZONE="Europe/Berlin")
     def test_formats_datetime_in_local_timezone(self):

--- a/xocto/localtime.py
+++ b/xocto/localtime.py
@@ -657,6 +657,18 @@ def is_aligned_to_midnight(
     )
 
 
+def ensure_midnight_aligned(
+    value: datetime_.date | datetime_.datetime | None,
+) -> datetime_.datetime | None:
+    """
+    Return a localtime midnight-aligned, timezone-aware datetime for the
+    given value, or None if value is None.
+    """
+    if value is None:
+        return None
+    return midnight(value)
+
+
 def consolidate_into_intervals(
     dates: Sequence[datetime_.date],
 ) -> Sequence[Tuple[datetime_.date, datetime_.date]]:


### PR DESCRIPTION
# :rocket: Description

### :information_desk_person: Why is this change needed?

As part of reworking datetime usages across the Contract framework, we need a utility to normalise dates and datetimes to localtime midnight-aligned, timezone-aware datetimes at the GraphQL interface boundary. This adds `ensure_midnight_aligned()` to `xocto.localtime`, making it available as a shared utility for Kraken-wide use rather than a one-off in a single domain.

#### :paperclip: [Asana ticket](https://app.asana.com/1/696560454032998/project/1209211066248610/task/1213811441009207?focus=true)

### :sparkles: Type of change

- [x] New feature (non-breaking change which adds functionality)

<!--
# :test_tube: How to test locally

[comment]: <> (Please provide step-by-step instructions for how to test this change locally.)
[comment]: <> (Include relevant commands, configuration, and expected results.)

### Setup
[comment]: <> (e.g. Which client/territory to use, any environment variables, database setup, etc.)

### Testing steps
[comment]: <> (Step-by-step instructions to verify the change works as expected)

### Expected results
[comment]: <> (What should happen when testing is successful?)


# :camera: Attachments

[comment]: <> (If your feature has a view or needs materials.)


### :pencil2: Checklist before requesting a review

Before merging, ensure the below points have been considered:
- [ ] *Deployment:* [This pull request will deploy to all Krakens without error](https://github.com/octoenergy/kraken-core/blob/master/docs/getting-started/deploypipeline/ref/pre_merge_checks.md#deployment "e.g. Consul config, migrations, static files")
- [ ] *Privacy:* [No personally identifiable information is published to Datadog or Sentry](https://github.com/octoenergy/kraken-core/blob/master/docs/getting-settings/deploypipeline/ref/pre_merge_checks.md#privacy "e.g. no customer names, emails, phone numbers of addresses")
- [ ] *Audit:* [Appropriate records are published to provide an audit trail](https://github.com/octoenergy/kraken-core/blob/master/docs/getting-started/deploypipeline/ref/pre_merge_checks.md#audit "e.g. Log events or database event records").
- [ ] *Comms:* [A "what's new?" post is included if support staff should know about this change](https://github.com/octoenergy/kraken-core/blob/master/docs/getting-started/deploypipeline/ref/pre_merge_checks.md#comms).
-->