### PR TITLE
Bump version to v9.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Drop Postgres 13 support [#262](https://github.com/octoenergy/xocto/pull/262)
 - Pin max version of `pact-python` to <3.0.0 [#261](https://github.com/octoenergy/xocto/pull/261)
 
+## V9.0.3 - 2026-04-17
+
+- Add `ensure_midnight_aligned` function to `localtime` module [#265](https://github.com/octoenergy/xocto/pull/265)
+
 ## V9.0.2 - 2026-01-13
 
 - Update `Comparable` protocol parameters as positional-only [#259](https://github.com/octoenergy/xocto/pull/259)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xocto"
-version = "9.0.2"
+version = "9.0.3"
 requires-python = ">=3.10"
 description = "Kraken Technologies Python service utilities"
 readme = "README.md"


### PR DESCRIPTION
Updated changelog file to reflect change introduced in PR https://github.com/octoenergy/xocto/pull/265

Backported commit in tag [v9.0.3](https://github.com/octoenergy/xocto/releases/tag/v9.0.3)