### PR TITLE
Configure Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This adds Dependabot version updates for **GitHub Actions**, keeping actions such as `actions/checkout` current.

It mirrors the configuration used in the main octoenergy repositories (e.g. `kraken-core`): Dependabot will open weekly PRs for any outdated actions referenced under `.github/workflows/`.

Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference

Raised as part of a sweep to add GitHub Actions Dependabot coverage to active repos that were missing it. Opened as a draft for review.