### PR TITLE
Validate finite range endpoints

### DIFF
--- a/tests/fields/postgres/test_ranges.py
+++ b/tests/fields/postgres/test_ranges.py
@@ -469,11 +469,11 @@ class TestHalfFiniteDateTimeRangeField:
             half_finite_datetime_range=half_finite_datetime_range_melb,
             half_finite_datetime_range_utc=half_finite_datetime_range_melb,
         )
-        half_finite_datetime_range_london = ranges.FiniteDatetimeRange(
+        half_finite_datetime_range_london = ranges.HalfFiniteDatetimeRange(
             start=localtime.as_localtime(half_finite_datetime_range_melb.start),
             end=None,
         )
-        half_finite_datetime_range_utc = ranges.FiniteDatetimeRange(
+        half_finite_datetime_range_utc = ranges.HalfFiniteDatetimeRange(
             start=localtime.as_utc(half_finite_datetime_range_melb.start),
             end=None,
         )

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -519,9 +519,20 @@ class TestHalfFiniteRange:
         assert 1 == r.start
         assert 2 == r.end
 
+    def test_rejects_missing_start(self):
+        with pytest.raises(ValueError, match="HalfFiniteRange start cannot be None"):
+            ranges.HalfFiniteRange(None)
+
     def test_does_not_have_instance_dictionary(self):
         r = ranges.HalfFiniteRange(0, 2)
         assert not hasattr(r, "__dict__")
+
+
+class TestFiniteRange:
+    @pytest.mark.parametrize("start,end", [(None, 1), (1, None), (None, None)])
+    def test_rejects_missing_endpoints(self, start, end):
+        with pytest.raises(ValueError, match="FiniteRange endpoints cannot be None"):
+            ranges.FiniteRange(start, end)
 
 
 ONE_DAY = datetime.timedelta(days=1)

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -523,6 +523,16 @@ class TestHalfFiniteRange:
         with pytest.raises(ValueError, match="HalfFiniteRange start cannot be None"):
             ranges.HalfFiniteRange(None)
 
+    def test_endpoints_are_immutable(self):
+        r = ranges.HalfFiniteRange(0, 1)
+
+        with pytest.raises(AttributeError, match="Can't set attributes"):
+            r.start = None
+        with pytest.raises(AttributeError, match="Can't set attributes"):
+            r.end = r.start
+
+        assert r == ranges.HalfFiniteRange(0, 1)
+
     def test_does_not_have_instance_dictionary(self):
         r = ranges.HalfFiniteRange(0, 2)
         assert not hasattr(r, "__dict__")
@@ -533,6 +543,16 @@ class TestFiniteRange:
     def test_rejects_missing_endpoints(self, start, end):
         with pytest.raises(ValueError, match="FiniteRange endpoints cannot be None"):
             ranges.FiniteRange(start, end)
+
+    def test_endpoints_are_immutable(self):
+        r = ranges.FiniteRange(0, 1)
+
+        with pytest.raises(AttributeError, match="Can't set attributes"):
+            r.start = None
+        with pytest.raises(AttributeError, match="Can't set attributes"):
+            r.end = None
+
+        assert r == ranges.FiniteRange(0, 1)
 
 
 ONE_DAY = datetime.timedelta(days=1)

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -293,7 +293,7 @@ class Range(Generic[T]):
         return f"<Range: {str(self)}>"
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if name in type(self).__slots__:
+        if any(name in getattr(cls, "__slots__", ()) for cls in type(self).__mro__):
             raise AttributeError("Can't set attributes")
         else:
             super().__setattr__(name, value)

--- a/xocto/ranges.py
+++ b/xocto/ranges.py
@@ -558,6 +558,18 @@ class FiniteRange(Range[T]):
     _start_normalised: T
     _end_normalised: T
 
+    def __init__(
+        self,
+        start: T,
+        end: T,
+        *,
+        boundaries: Union[str, RangeBoundaries] = RangeBoundaries.INCLUSIVE_EXCLUSIVE,
+    ):
+        if any(value is None for value in (start, end)):
+            raise ValueError("FiniteRange endpoints cannot be None")
+
+        super().__init__(start, end, boundaries=boundaries)
+
     @property  # type: ignore[override]
     def start(self) -> T:
         return self._start_original
@@ -614,6 +626,9 @@ class HalfFiniteRange(Range[T]):
         self._start_normalised, _ = _normalise_datetimes(value, None)
 
     def __init__(self, start: T, end: Optional[T] = None):
+        if start is None:
+            raise ValueError("HalfFiniteRange start cannot be None")
+
         super().__init__(start, end, boundaries=RangeBoundaries.INCLUSIVE_EXCLUSIVE)
 
     def intersection(self, other: Range[T]) -> Optional["HalfFiniteRange[T]"]:


### PR DESCRIPTION
In order to improve robustness, this PR forbids setting the bounds of existing ranges.